### PR TITLE
Make `@sap/cds` a peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
   ],
   "dependencies": {
     "@cap-js/attachments": "latest",
-    "@sap/cds": "^7",
     "@sap/cds-lsp": "^7.6.1",
     "@sap/xssec": "^3.6.1",
     "axios": "^1.7.0",
@@ -29,6 +28,9 @@
     "express": "^4",
     "node-cache": "^5.1.2",
     "request": "^2.88.2"
+  },
+  "peerDependencies": {
+    "@sap/cds": ">=7"
   },
   "devDependencies": {
     "@cap-js/sqlite": "^1",


### PR DESCRIPTION
Like w/ all other plugins, `@sap/cds` should be installed by the application, not by the plugin.

Also, support upcoming cds 8.  Please check if this works.