### PR TITLE
Remove unused request library

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,8 +25,7 @@
     "axios": "^1.7.0",
     "dotenv": "^16.3.1",
     "express": "^4",
-    "node-cache": "^5.1.2",
-    "request": "^2.88.2"
+    "node-cache": "^5.1.2"
   },
   "peerDependencies": {
     "@sap/cds": ">=7"


### PR DESCRIPTION
Removed unused "request" library from package.json. This will fix Blackduck critical security risk.