### PR TITLE
Rename Attachments Bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 ## Version 1.2.2
 
 ### Fixed
-App crash issue on update of fields when no attachments are added.
+
+ - App crash issue on update of fields when no attachments are added.
+ - Attachment getting renamed even when duplicate attachment of same name exists.
 
 ## Version 1.2.1
 

--- a/lib/sdm.js
+++ b/lib/sdm.js
@@ -366,7 +366,7 @@ async isFileNameDuplicateInDrafts(data,req) {
           token
         );
 
-        if (response.status ==  undefined && response.response.status !=200) {
+        if (response.status != 200) {
           //modify req.data.attachments
           for(let i = 0; i < req.data.attachments.length; i++) {
             let attachmentUpdate = req.data.attachments[i];


### PR DESCRIPTION
This PR resolves a bug where renaming an attachment to a name that already exists in the DI backend did not trigger an error.
