### PR TITLE
[SDMEXT-590] Display attachments specific to repository

### DIFF
--- a/index.cds
+++ b/index.cds
@@ -27,4 +27,5 @@ annotate Attachments with @UI:{
   folderId @UI.Hidden;
   mimeType @UI.Hidden;
   status @UI.Hidden;
+  repositoryId @UI.Hidden;
 }

--- a/index.cds
+++ b/index.cds
@@ -1,8 +1,8 @@
 using { Attachments} from '@cap-js/attachments';
 extend aspect Attachments with {
     folderId : String @title: 'Folder ID' @readonly;
+    repositoryId : String @title: 'Repository ID' @readonly default null;
 };
-
 annotate Attachments with @UI:{
   HeaderInfo: {
     TypeName: '{i18n>Attachment}',

--- a/lib/persistence/index.js
+++ b/lib/persistence/index.js
@@ -5,12 +5,16 @@ async function getURLFromAttachments(keys, attachments) {
   return await SELECT.from(attachments, keys).columns("url");
 }
 
-async function getDraftAttachments(attachments, req) {
+async function getDraftAttachments(attachments, req, repositoryId) {
   const up_ = attachments.keys.up_.keys[0].$generatedFieldName;
   const idValue = up_.split("__")[1];
+  const conditions = {
+    [up_]: req.data[idValue],
+    repositoryId: repositoryId
+  };
   return await SELECT("filename", "mimeType", "content", "url", "ID", "HasActiveEntity")
     .from(attachments.drafts)
-    .where({ [up_]: req.data[idValue] })
+    .where(conditions)
 }
 
 async function getFolderIdForEntity(attachments, req, repositoryId) {

--- a/lib/persistence/index.js
+++ b/lib/persistence/index.js
@@ -1,5 +1,6 @@
 const cds = require("@sap/cds/lib");
-const { SELECT } = cds.ql;
+const { SELECT, UPDATE } = cds.ql;
+const { readAttachment } = require("../handler/index");
 
 async function getURLFromAttachments(keys, attachments) {
   return await SELECT.from(attachments, keys).columns("url");
@@ -33,10 +34,26 @@ async function getExistingAttachments(attachmentIDs, attachments) {
     .where({ ID: { in: [...attachmentIDs] }});
 }
 
+async function setRepositoryId(attachments, repositoryId) {
+  let nullAttachments = await SELECT()
+    .from(attachments)
+    .where({ repositoryId: null });
+
+  for (let attachment of nullAttachments) {
+    let attachmentData = await readAttachment(attachment);
+    if (attachmentData !== null) {
+      await UPDATE(attachments)
+        .set({ repositoryId: repositoryId })
+        .where({ id: attachment.id });
+    }
+  }
+}
+
 module.exports = {
   getDraftAttachments,
   getURLsToDeleteFromAttachments,
   getURLFromAttachments,
   getFolderIdForEntity,
-  getExistingAttachments
+  getExistingAttachments,
+  setRepositoryId
 };

--- a/lib/persistence/index.js
+++ b/lib/persistence/index.js
@@ -1,6 +1,5 @@
 const cds = require("@sap/cds/lib");
 const { SELECT, UPDATE } = cds.ql;
-const { readAttachment } = require("../handler/index");
 
 async function getURLFromAttachments(keys, attachments) {
   return await SELECT.from(attachments, keys).columns("url");
@@ -14,12 +13,16 @@ async function getDraftAttachments(attachments, req) {
     .where({ [up_]: req.data[idValue] })
 }
 
-async function getFolderIdForEntity(attachments, req) {
+async function getFolderIdForEntity(attachments, req, repositoryId) {
   const up_ = attachments.keys.up_.keys[0].$generatedFieldName;
   const idValue = up_.split("__")[1];
+  const conditions = {
+    [up_]: req.data[idValue],
+    repositoryId: repositoryId
+  };
   return await SELECT.from(attachments)
     .columns("folderId")
-    .where({ [up_]: req.data[idValue] });
+    .where(conditions);
 }
 
 async function getURLsToDeleteFromAttachments(deletedAttachments, attachments) {
@@ -35,19 +38,23 @@ async function getExistingAttachments(attachmentIDs, attachments) {
 }
 
 async function setRepositoryId(attachments, repositoryId) {
-  let nullAttachments = await SELECT()
+  if(attachments){
+    let nullAttachments = await SELECT()
     .from(attachments)
     .where({ repositoryId: null });
 
+  if (!nullAttachments || nullAttachments.length === 0) {
+    return; 
+  }
+
   for (let attachment of nullAttachments) {
-    let attachmentData = await readAttachment(attachment);
-    if (attachmentData !== null) {
-      await UPDATE(attachments)
-        .set({ repositoryId: repositoryId })
-        .where({ id: attachment.id });
-    }
+    await UPDATE(attachments)
+      .set({ repositoryId: repositoryId })
+      .where({ ID: attachment.ID });
+  }
   }
 }
+
 
 module.exports = {
   getDraftAttachments,

--- a/lib/sdm.js
+++ b/lib/sdm.js
@@ -161,8 +161,9 @@ module.exports = class SDMAttachmentsService extends (
   }
 
 
-  async  getParentId(attachments,req,token){
-    const folderIds = await getFolderIdForEntity(attachments, req);
+  async getParentId(attachments,req,token){
+    const { repositoryId } = getConfigurations();
+    const folderIds = await getFolderIdForEntity(attachments, req, repositoryId);
     let parentId = "";
     if (folderIds?.length == 0) {
       const folderId = await getFolderIdByPath(
@@ -206,13 +207,15 @@ module.exports = class SDMAttachmentsService extends (
   }
 
   async filterAttachments(req) {
-    const attachments =
-      cds.model.definitions[req.query.target.name + ".attachments"];
-    const { repositoryId } = getConfigurations(); // Fetch repositoryId from configurations
-    await setRepositoryId(attachments, repositoryId);
+    const { repositoryId } = getConfigurations();
     if (!req.query.SELECT.where) {
       req.query.SELECT.where = [];
     }
+    
+    if (req.query.SELECT.where.length > 0) {
+      req.query.SELECT.where.push('and');
+    }
+
     req.query.SELECT.where.push(
       { ref: ['repositoryId'] },
       '=',
@@ -220,6 +223,13 @@ module.exports = class SDMAttachmentsService extends (
     );
   }
   
+  async setRepository(req) {
+    const attachments =
+      cds.model.definitions[req.query.target.name];
+    const { repositoryId } = getConfigurations(); // Fetch repositoryId from configurations
+    await setRepositoryId(attachments, repositoryId)
+  }
+
   async attachDeletionData(req) {
     await this.checkRepositoryType(req);
     const attachments =
@@ -430,6 +440,7 @@ module.exports = class SDMAttachmentsService extends (
       entity,
       this.attachDeletionData.bind(this)
     );
+    srv.before("READ", [target,target.drafts], this.setRepository.bind(this))
     srv.before("READ", [target,target.drafts], this.filterAttachments.bind(this))
     srv.before("SAVE", entity, this.draftSaveHandler.bind(this));
     srv.after(

--- a/lib/sdm.js
+++ b/lib/sdm.js
@@ -72,9 +72,10 @@ module.exports = class SDMAttachmentsService extends (
   }
 
   async draftSaveHandler(req) {
+    const { repositoryId } = getConfigurations();
     await this.checkRepositoryType(req);
     const attachments = cds.model.definitions[req.query.target.name + ".attachments"];
-    const attachment_val = await getDraftAttachments(attachments, req);
+    const attachment_val = await getDraftAttachments(attachments, req, repositoryId);
 
     if (attachment_val.length > 0) {
       await this.isFileNameDuplicateInDrafts(attachment_val,req);

--- a/lib/sdm.js
+++ b/lib/sdm.js
@@ -10,7 +10,7 @@ const {
   deleteFolderWithAttachments,
   readAttachment,
   renameAttachment
-} = require("../lib/handler");
+} = require("./handler/index");
 const {
   fetchAccessToken,
   checkAttachmentsToRename,
@@ -22,7 +22,8 @@ const {
   getDraftAttachments,
   getURLsToDeleteFromAttachments,
   getURLFromAttachments,
-  getFolderIdForEntity
+  getFolderIdForEntity,
+  setRepositoryId
 } = require("../lib/persistence");
 const { duplicateDraftFileErr, emptyFileErr, renameFileErr, virusFileErr, duplicateFileErr, versionedRepositoryErr, otherFileErr } = require("./util/messageConsts");
 
@@ -187,7 +188,7 @@ module.exports = class SDMAttachmentsService extends (
     return parentId;
   }
 
-async isFileNameDuplicateInDrafts(data,req) {
+  async isFileNameDuplicateInDrafts(data,req) {
     let fileNames = [];
     for (let index in data) {
       fileNames.push(data[index].filename);
@@ -204,6 +205,21 @@ async isFileNameDuplicateInDrafts(data,req) {
     }
   }
 
+  async filterAttachments(req) {
+    const attachments =
+      cds.model.definitions[req.query.target.name + ".attachments"];
+    const { repositoryId } = getConfigurations(); // Fetch repositoryId from configurations
+    await setRepositoryId(attachments, repositoryId);
+    if (!req.query.SELECT.where) {
+      req.query.SELECT.where = [];
+    }
+    req.query.SELECT.where.push(
+      { ref: ['repositoryId'] },
+      '=',
+      { val: repositoryId }
+    );
+  }
+  
   async attachDeletionData(req) {
     await this.checkRepositoryType(req);
     const attachments =
@@ -299,6 +315,7 @@ async isFileNameDuplicateInDrafts(data,req) {
       Ids = [],
       success = [],
       success_ids = [];
+    const { repositoryId } = getConfigurations();
     await Promise.all(
       data.map(async (d) => {
         // Check if d.content is null
@@ -316,6 +333,7 @@ async isFileNameDuplicateInDrafts(data,req) {
           if (response.status == 201) {
             d.folderId = parentId;
             d.url = response.data.succinctProperties["cmis:objectId"];
+            d.repositoryId = repositoryId;
             d.content = null;
             success_ids.push(d.ID);
             success.push(d);
@@ -406,12 +424,13 @@ async isFileNameDuplicateInDrafts(data,req) {
     return "Clean";
   }
 
-  registerUpdateHandlers(srv, entity) {
+  registerUpdateHandlers(srv, entity, target) {
     srv.before(
       ["DELETE", "UPDATE"],
       entity,
       this.attachDeletionData.bind(this)
     );
+    srv.before("READ", [target,target.drafts], this.filterAttachments.bind(this))
     srv.before("SAVE", entity, this.draftSaveHandler.bind(this));
     srv.after(
       ["DELETE", "UPDATE"],

--- a/package.json
+++ b/package.json
@@ -66,5 +66,8 @@
         }
       }
     }
+  },
+  "overrides": {
+    "inflight": "../_EXCLUDED_"
   }
 }

--- a/package.json
+++ b/package.json
@@ -66,8 +66,5 @@
         }
       }
     }
-  },
-  "overrides": {
-    "inflight": "../_EXCLUDED_"
   }
 }

--- a/test/lib/sdm.test.js
+++ b/test/lib/sdm.test.js
@@ -11,7 +11,8 @@ const {
   getDraftAttachments,
   getURLsToDeleteFromAttachments,
   getURLFromAttachments,
-  getFolderIdForEntity
+  getFolderIdForEntity,
+  setRepositoryId
 } = require("../../lib/persistence");
 const {
   deleteAttachmentsOfFolder,
@@ -35,7 +36,8 @@ jest.mock("../../lib/persistence", () => ({
   getURLsToDeleteFromAttachments: jest.fn(),
   getURLFromAttachments: jest.fn(),
   getFolderIdForEntity: jest.fn(),
-  getExistingAttachments: jest.fn()
+  getExistingAttachments: jest.fn(),
+  setRepositoryId: jest.fn()
 }));
 jest.mock("../../lib/util", () => ({
   fetchAccessToken: jest.fn(),
@@ -73,7 +75,7 @@ describe("SDMAttachmentsService", () => {
     beforeEach(() => {
 
       NodeCache.prototype.get.mockClear();
-      jest.resetAllMocks();
+      jest.clearAllMocks();
       service = new SDMAttachmentsService();
       service.creds = { uri: "mock_cred" };
       repoInfo = {
@@ -293,7 +295,7 @@ cds.context = {
     let repoInfo;
     beforeEach(() => {
       NodeCache.prototype.get.mockClear();
-      jest.resetAllMocks();
+      jest.clearAllMocks();
       cds = require("@sap/cds/lib");
       service = new SDMAttachmentsService();
       service.creds = { uaa: "mocked uaa" };
@@ -341,7 +343,9 @@ cds.context = {
               },
           };
       NodeCache.prototype.get.mockImplementation(() => undefined);
-      getConfigurations.mockResolvedValueOnce({repositoryId: "123"});
+      getConfigurations.mockReturnValue({
+        repositoryId: 'mockRepositoryId',
+      });
       getRepositoryInfo.mockResolvedValueOnce(repoInfo);
       isRepositoryVersioned.mockResolvedValueOnce(false);
     });
@@ -459,6 +463,96 @@ cds.context = {
     });
   });
 
+  describe("Test filterAttachments", () => {
+    let service;
+    let mockReq;
+    beforeEach(() => {
+      jest.clearAllMocks();
+      service = new SDMAttachmentsService();
+      getConfigurations.mockReturnValue({
+        repositoryId: 'mockRepositoryId',
+      });
+      mockReq = {
+        query: {
+          SELECT: {},
+        },
+        user: {
+          tokenInfo: {
+            getTokenValue: jest.fn().mockReturnValue("mocked_token"),
+          }
+        }
+      }
+    });
+
+    it("should add a condition to filter attachments by repositoryId when where clause is empty", async() => {
+      mockReq.query.SELECT.where = [];
+      await service.filterAttachments(mockReq);
+      expect(mockReq.query.SELECT.where).toEqual([
+        { ref: ['repositoryId'] },
+        '=',
+        { val: "mockRepositoryId" }
+      ]); 
+    });
+
+    it("should add a condition to filter attachments by repositoryId when where clause already exists", async() => {
+      mockReq.query.SELECT.where = [{ ref: ['someField'] }, '=', { val: 'someValue' }];
+      await service.filterAttachments(mockReq);
+      expect(mockReq.query.SELECT.where).toEqual([
+        { ref: ['someField'] },
+        '=',
+        { val: 'someValue' },
+        'and',
+        { ref: ['repositoryId'] },
+        '=',
+        { val: "mockRepositoryId" }
+      ]); 
+    });
+
+    it("should add a condition to filter attachments by repositoryId when where clause doesn't exist", async() => {
+      await service.filterAttachments(mockReq);
+      expect(mockReq.query.SELECT.where).toEqual([
+        { ref: ['repositoryId'] },
+        '=',
+        { val: "mockRepositoryId" }
+      ]);
+    });
+  });
+
+  describe("Test setRepository", () => {
+    let service;
+    beforeEach(() => {
+      jest.clearAllMocks();
+  
+      service = new SDMAttachmentsService();
+      cds = require("@sap/cds/lib");
+
+      getConfigurations.mockReturnValue({
+        repositoryId: 'mockRepositoryId',
+      });
+    });
+  
+    it("should call setRepositoryId with correct arguments", async () => {
+      const mockReq = {
+        query: {
+          target: {
+            name: 'Attachments',
+          },
+        },
+      };
+      let mockedAttachments = { entity: 'AttachmentsEntity' };
+      cds.model.definitions = {
+        Attachments: mockedAttachments,
+      };
+      await service.setRepository(mockReq);
+  
+      expect(setRepositoryId).toHaveBeenCalledWith(
+        mockedAttachments,
+        "mockRepositoryId"
+      );
+    });
+  });
+  
+
   describe("attachDeletionData", () => {
     let service;
     let repoInfo;
@@ -571,8 +665,12 @@ cds.context = {
     });
 
     it("attachDeletionData() should set req.parentId if event is DELETE and getFolderIdForEntity() returns non-empty array", async () => {
-      const mockReq = {
-        query: { target: { name: "testName" } },
+      const mockedReq = {
+        query: {
+          target: {
+            name: 'Attachments',
+          },
+        },
         user: {
           tokenInfo: {
             getTokenValue: jest.fn().mockReturnValue("tokenValue"),
@@ -581,19 +679,26 @@ cds.context = {
         diff: () =>
           Promise.resolve({ attachments: [{ _op: "delete", ID: "1" }] }),
         event: "DELETE",
+      };
+
+      let mockedAttachments = { entity: 'AttachmentsEntity' };
+      cds.model.definitions = {
+        "Attachments.attachments": mockedAttachments,
       };
 
       getURLsToDeleteFromAttachments.mockResolvedValueOnce(["url"]);
       getFolderIdByPath.mockResolvedValueOnce("folder");
-      await service.attachDeletionData(mockReq);
-      expect(mockReq.parentId).toEqual("folder");
+      await service.attachDeletionData(mockedReq);
+      expect(mockedReq.parentId).toEqual("folder");
       expect(getFolderIdByPath).toHaveBeenCalledTimes(1);
     });
 
     it("attachDeletionData() should not set req.parentId if event is DELETE and getFolderIdForEntity() returns empty array", async () => {
-      const mockReq = {
+      const mockedReq = {
         query: {
-          target: { name: "testName" },
+          target: {
+            name: 'Attachments',
+          },
         },
         user: {
           tokenInfo: {
@@ -605,10 +710,15 @@ cds.context = {
         event: "DELETE",
       };
 
+      let mockedAttachments = { entity: 'AttachmentsEntity' };
+      cds.model.definitions = {
+        "Attachments.attachments": mockedAttachments,
+      };
+
       getURLsToDeleteFromAttachments.mockResolvedValueOnce(["url"]);
       getFolderIdByPath.mockResolvedValueOnce(null);
-      await service.attachDeletionData(mockReq);
-      expect(mockReq.parentId).toBeUndefined();
+      await service.attachDeletionData(mockedReq);
+      expect(mockedReq.parentId).toBeUndefined();
       expect(getFolderIdByPath).toHaveBeenCalledTimes(1);
     });
 
@@ -1043,6 +1153,7 @@ cds.context = {
         filename: "filename2",
         ID: "id2",
         folderId: parentId,
+        repositoryId: "mockRepositoryId",
         url: "some_object_id",
       });
     });
@@ -1260,7 +1371,8 @@ cds.context = {
  
       expect(getFolderIdForEntity).toHaveBeenCalledWith(
         cds.model.definitions[mockReq.query.target.name + ".attachments"],
-        mockReq
+        mockReq,
+        "mockRepositoryId"
       );
     });  
   });


### PR DESCRIPTION
This PR adds the check for repository ID, so that the user does not see attachments that were uploaded to a different repository, than the one with which the application is currently deployed. It also fixes the bug when using multiple repositories, if the application is deployed with a repository and an entity is created with a few attachments in them, a folder is created for that entity in the repository. When deployed with a different repository, it will find the folderId from the db and try to create attachments in it, but it will fail as the folder was created with a different repository. This is resolved by adding a repositoryId check while looking for folder. It also modifies the duplicate file check to check only in the current repository.

JIRA BL : [SDMEXT-590](https://jira.tools.sap/browse/SDMEXT-590)