### PR TITLE
Bug Fix to delete attachment on discard of drafts

### DIFF
--- a/lib/persistence/index.js
+++ b/lib/persistence/index.js
@@ -53,6 +53,12 @@ async function getURLsToDeleteFromAttachments(deletedAttachments, attachments) {
     .where({ ID: { in: [...deletedAttachments] } });
 }
 
+async function getURLsToDeleteFromDraftAttachments(draftAttachments) {
+  return await SELECT.from(draftAttachments)
+    .columns("url")
+    .where({ HasActiveEntity: false });
+}
+
 async function getExistingAttachments(attachmentIDs, attachments) {
   return await SELECT("filename", "url", "ID", "folderId")
     .from(attachments)
@@ -82,6 +88,7 @@ module.exports = {
   getDraftAttachments,
   getDraftAttachmentsForUpID,
   getURLsToDeleteFromAttachments,
+  getURLsToDeleteFromDraftAttachments,
   getURLFromAttachments,
   getFolderIdForEntity,
   updateAttachmentInDraft,

--- a/lib/sdm.js
+++ b/lib/sdm.js
@@ -29,7 +29,7 @@ const {
   updateAttachmentInDraft,
   setRepositoryId
 } = require("../lib/persistence");
-const { duplicateDraftFileErr, renameFileErr, virusFileErr, duplicateFileErr, versionedRepositoryErr, otherFileErr, userDoesNotHaveScopeMessage, userNotAuthorisedError } = require("./util/messageConsts");
+const { duplicateDraftFileErr, renameFileErr, virusFileErr, duplicateFileErr, versionedRepositoryErr, otherFileErr, userDoesNotHaveRequiredScope, userNotAuthorisedError } = require("./util/messageConsts");
 
 module.exports = class SDMAttachmentsService extends (
   require("@cap-js/attachments/lib/basic")
@@ -199,7 +199,7 @@ module.exports = class SDMAttachmentsService extends (
           token,
           attachments
         );
-        if (response.status == 403 && response.response.data == userDoesNotHaveScopeMessage) {
+        if (response.status == 403 && response.response.data == userDoesNotHaveRequiredScope) {
           req.reject(403, userNotAuthorisedError);
         }
         parentId = response.data.succinctProperties["cmis:objectId"];
@@ -297,7 +297,7 @@ module.exports = class SDMAttachmentsService extends (
     let draftAttachments = cds.model.definitions[req.query.target.name.replace(/\.drafts$/, ".attachments.drafts")];
     if(draftAttachments)  {
       const attachmentsToDeleteFromDraft = await getURLsToDeleteFromDraftAttachments(draftAttachments);
-      if (attachmentsToDeleteFromDraft.length > 0) {
+      if (attachmentsToDeleteFromDraft?.length > 0) {
         req.attachmentsToDelete = attachmentsToDeleteFromDraft;
       }
       const diffData = await req.diff();

--- a/lib/sdm.js
+++ b/lib/sdm.js
@@ -386,10 +386,10 @@ module.exports = class SDMAttachmentsService extends (
         } else {
           fileNames.push(d.filename);
           if(response.response.data.message == 'Malware Service Exception: Virus found in the file!'){
-            req.reject(virusFileErr(fileNames));
+            req.reject(403, virusFileErr(fileNames));
           }
           else if(response.response.data.exception == "nameConstraintViolation"){
-            req.reject(duplicateFileErr(fileNames));
+            req.reject(409, duplicateFileErr(fileNames));
           }
           else{
             req.reject(otherFileErr(fileNames));

--- a/lib/sdm.js
+++ b/lib/sdm.js
@@ -23,6 +23,7 @@ const {
   getDraftAttachments,
   getDraftAttachmentsForUpID,
   getURLsToDeleteFromAttachments,
+  getURLsToDeleteFromDraftAttachments,
   getURLFromAttachments,
   getFolderIdForEntity,
   updateAttachmentInDraft,
@@ -256,23 +257,51 @@ module.exports = class SDMAttachmentsService extends (
       const diffData = await req.diff();
       let deletedAttachments = [];
       if(diffData.attachments){
-      diffData.attachments
-        .filter((object) => {
-          return object._op === "delete";
-        })
-        .map((attachment) => {
-          deletedAttachments.push(attachment.ID);
-        });
-      if (deletedAttachments.length > 0) {
-        const attachmentsToDelete = await getURLsToDeleteFromAttachments(
-          deletedAttachments,
-          attachments
-        );
-        if (attachmentsToDelete.length > 0) {
-          req.attachmentsToDelete = attachmentsToDelete;
+        diffData.attachments
+          .filter((object) => {
+            return object._op === "delete";
+          })
+          .map((attachment) => {
+            deletedAttachments.push(attachment.ID);
+          });
+        if (deletedAttachments.length > 0) {
+          const attachmentsToDelete = await getURLsToDeleteFromAttachments(
+            deletedAttachments,
+            attachments
+          );
+          if (attachmentsToDelete.length > 0) {
+            req.attachmentsToDelete = attachmentsToDelete;
+          }
+        }
+        if (req.event == "DELETE") {
+          const token = await fetchAccessToken(
+            this.creds,
+            req.user.tokenInfo.getTokenValue()
+          );
+          const folderId = await getFolderIdByPath(
+            req,
+            this.creds,
+            token,
+            attachments
+          );
+          if (folderId) {
+            req.parentId = folderId;
+          }
         }
       }
-      if (req.event == "DELETE") {
+    }
+  }
+
+  async attachDraftDeletionData(req) {
+    await this.checkRepositoryType(req);
+    let draftAttachments = cds.model.definitions[req.query.target.name.replace(/\.drafts$/, ".attachments.drafts")];
+    if(draftAttachments)  {
+      const attachmentsToDeleteFromDraft = await getURLsToDeleteFromDraftAttachments(draftAttachments);
+      if (attachmentsToDeleteFromDraft.length > 0) {
+        req.attachmentsToDelete = attachmentsToDeleteFromDraft;
+      }
+      const diffData = await req.diff();
+      if (req.event == "DELETE" && diffData.attachments?.length == req.attachmentsToDelete?.length) {
         const token = await fetchAccessToken(
           this.creds,
           req.user.tokenInfo.getTokenValue()
@@ -281,13 +310,12 @@ module.exports = class SDMAttachmentsService extends (
           req,
           this.creds,
           token,
-          attachments
+          draftAttachments
         );
         if (folderId) {
           req.parentId = folderId;
         }
       }
-    }
     }
   }
 
@@ -432,6 +460,11 @@ module.exports = class SDMAttachmentsService extends (
       entity,
       this.attachDeletionData.bind(this)
     );
+    srv.before(
+      ["DELETE", "UPDATE"],
+      entity.drafts,
+      this.attachDraftDeletionData.bind(this)
+    );
     srv.before("READ", [target, target.drafts], this.setRepository.bind(this))
     srv.before("READ", [target, target.drafts], this.filterAttachments.bind(this))
     srv.before("SAVE", entity, this.renameHandler.bind(this));
@@ -444,7 +477,7 @@ module.exports = class SDMAttachmentsService extends (
     }
     srv.after(
       ["DELETE", "UPDATE"],
-      entity,
+      [entity, entity.drafts],
       this.deleteAttachmentsWithKeys.bind(this)
     );
   }

--- a/lib/util/messageConsts.js
+++ b/lib/util/messageConsts.js
@@ -18,5 +18,5 @@ module.exports.otherFileErr = (otherFiles) => {
 };
 module.exports.versionedRepositoryErr = 'Attachments are not supported for a versioned repository.';
 module.exports.userNotAuthorisedError  = 'You do not have the required permissions to upload attachments. Please contact your administrator for access.';
-module.exports.userDoesNotHaveScopeMessage = 'User does not have required scope';
+module.exports.userDoesNotHaveRequiredScope = 'User does not have the required scope';
 module.exports.errorMessage = 'An error occurred';

--- a/lib/util/messageConsts.js
+++ b/lib/util/messageConsts.js
@@ -18,5 +18,5 @@ module.exports.otherFileErr = (otherFiles) => {
 };
 module.exports.versionedRepositoryErr = 'Attachments are not supported for a versioned repository.';
 module.exports.userNotAuthorisedError  = 'You do not have the required permissions to upload attachments. Please contact your administrator for access.';
-module.exports.userDoesNotHaveScope = 'User does not have required scope';
+module.exports.userDoesNotHaveScopeMessage = 'User does not have required scope';
 module.exports.errorMessage = 'An error occurred';

--- a/test/lib/sdm.test.js
+++ b/test/lib/sdm.test.js
@@ -1202,13 +1202,13 @@ describe("SDMAttachmentsService", () => {
     it('should reject when a virus is found in the file', async () => {
       createAttachment
       .mockResolvedValueOnce({
-        status: 500,
+        status: 403,
         response: { data: { message: "Malware Service Exception: Virus found in the file!" } }
       });
   
       await service.onCreate(data, credentials, token, req, parentId);
   
-      expect(req.reject).toHaveBeenCalledWith(virusFileErr(['file1']));
+      expect(req.reject).toHaveBeenCalledWith(403, virusFileErr(['file1']));
     });
   
     it('should reject when there is a name constraint violation', async () => {
@@ -1220,7 +1220,7 @@ describe("SDMAttachmentsService", () => {
   
       await service.onCreate(data, credentials, token, req, parentId);
   
-      expect(req.reject).toHaveBeenCalledWith(duplicateFileErr(['file1']));
+      expect(req.reject).toHaveBeenCalledWith(409, duplicateFileErr(['file1']));
     });
   
     it('should reject when another error occurs', async () => {

--- a/test/lib/sdm.test.js
+++ b/test/lib/sdm.test.js
@@ -34,7 +34,7 @@ const {
   duplicateFileErr,
   otherFileErr,
   userNotAuthorisedError,
-  userDoesNotHaveScopeMessage,
+  userDoesNotHaveRequiredScope,
   versionedRepositoryErr
 } = require("../../lib/util/messageConsts");
 
@@ -1397,7 +1397,7 @@ describe("SDMAttachmentsService", () => {
       );
     });
   
-    it("getParentId should reject with 403 if createFolder response status is 403 and message matches userDoesNotHaveScopeMessage", async () => {
+    it("getParentId should reject with 403 if createFolder response status is 403 and message matches userDoesNotHaveRequiredScope", async () => {
       let attachments = cds.model.definitions[mockReq.query.target.name + ".attachments"];
       let token = "mocked_token";
       getFolderIdForEntity.mockResolvedValueOnce([]);
@@ -1405,7 +1405,7 @@ describe("SDMAttachmentsService", () => {
       createFolder.mockResolvedValueOnce({
         status: 403,
         response: {
-          data: userDoesNotHaveScopeMessage
+          data: userDoesNotHaveRequiredScope
         },
         data: {
           succinctProperties: {

--- a/test/lib/sdm.test.js
+++ b/test/lib/sdm.test.js
@@ -11,6 +11,7 @@ const {
   getDraftAttachments,
   getDraftAttachmentsForUpID,
   getURLsToDeleteFromAttachments,
+  getURLsToDeleteFromDraftAttachments,
   getURLFromAttachments,
   getFolderIdForEntity,
   updateAttachmentInDraft,
@@ -43,6 +44,7 @@ jest.mock("../../lib/persistence", () => ({
   getDraftAttachmentsForUpID: jest.fn(),
   getDuplicateAttachments: jest.fn(),
   getURLsToDeleteFromAttachments: jest.fn(),
+  getURLsToDeleteFromDraftAttachments: jest.fn(),
   getURLFromAttachments: jest.fn(),
   getFolderIdForEntity: jest.fn(),
   updateAttachmentInDraft: jest.fn(),
@@ -1324,6 +1326,7 @@ describe("SDMAttachmentsService", () => {
     let mockReq;
     let cds;
     beforeEach(() => {
+      NodeCache.prototype.get.mockClear();
       jest.clearAllMocks();
       cds = require("@sap/cds/lib");
       getConfigurations.mockReturnValue({ repositoryId: 'repo123' });
@@ -1403,14 +1406,15 @@ describe("SDMAttachmentsService", () => {
         status: 403,
         response: {
           data: userDoesNotHaveScopeMessage
+        },
+        data: {
+          succinctProperties: {
+            "cmis:objectId": "mock_object_id"
+          }
         }
       });
 
-      try {
-        await service.getParentId(attachments, mockReq, token);
-      } catch (err) {
-        console.error("Error in getParentId:", err);
-      }
+      await service.getParentId(attachments, mockReq, token);
 
       expect(mockReq.reject).toHaveBeenCalledWith(403, userNotAuthorisedError);
     });
@@ -1544,6 +1548,117 @@ describe("SDMAttachmentsService", () => {
     });
   });
 
+  describe("attachDraftDeletionData", () => {
+    let service;
+    let mockReq;
+    let mockDraftAttachments;
+    let cds;
+  
+    beforeEach(() => {
+      jest.clearAllMocks();
+      cds = require("@sap/cds/lib");
+      service = new SDMAttachmentsService();
+      jest.spyOn(service, 'checkRepositoryType').mockResolvedValue();
+  
+      mockReq = {
+        query: {
+          target: {
+            name: "testName.drafts",
+          },
+        },
+        event: "DELETE",
+        user: {
+          tokenInfo: {
+            getTokenValue: jest.fn().mockReturnValue("mocked_token"),
+          },
+        },
+        diff: jest.fn(),
+      };
+  
+      cds.model.definitions["testName.attachments.drafts"] = {};
+    });
+  
+    it("should attach attachments to delete in req when they are present in drafts", async () => {
+      mockDraftAttachments = cds.model.definitions["testName.attachments.drafts"];
+  
+      const attachmentsToDelete = ["attachment1", "attachment2"];
+      getURLsToDeleteFromDraftAttachments.mockResolvedValueOnce(attachmentsToDelete);
+  
+      mockReq.diff.mockResolvedValueOnce({
+        attachments: ["attachment1", "attachment2"],
+      });
+  
+      fetchAccessToken.mockResolvedValueOnce("mocked_token");
+      getFolderIdByPath.mockResolvedValueOnce("mock_folder_id");
+  
+      await service.attachDraftDeletionData(mockReq);
+  
+      expect(service.checkRepositoryType).toHaveBeenCalledWith(mockReq);
+      expect(getURLsToDeleteFromDraftAttachments).toHaveBeenCalledWith(mockDraftAttachments);
+      expect(mockReq.attachmentsToDelete).toEqual(attachmentsToDelete);
+      expect(mockReq.parentId).toEqual("mock_folder_id");
+    });
+  
+    it("should not set `parentId` if the number of attachments in diff is different from `attachmentsToDelete`", async () => {
+      const attachmentsToDelete = ["attachment1"];
+      getURLsToDeleteFromDraftAttachments.mockResolvedValueOnce(attachmentsToDelete);
+  
+      mockReq.diff.mockResolvedValueOnce({
+        attachments: ["attachment1", "attachment2", "attachment3"],
+      });
+  
+      await service.attachDraftDeletionData(mockReq);
+      
+      expect(mockReq.parentId).toBeUndefined();
+    });
+  
+    it("should not attach attachments to delete if no draft attachments are found", async () => {
+      delete cds.model.definitions["testName.attachments.drafts"];
+      getURLsToDeleteFromDraftAttachments.mockResolvedValueOnce([]);
+  
+      await service.attachDraftDeletionData(mockReq);
+  
+      expect(mockReq.attachmentsToDelete).toBeUndefined();
+    });
+
+    it("should not set attachmentsToDelete if attachmentsToDeleteFromDraft is empty", async () => {
+  
+      getURLsToDeleteFromDraftAttachments.mockResolvedValueOnce([]); // Empty array to simulate no deletions
+  
+      mockReq.diff.mockResolvedValueOnce({
+        attachments: ["attachment1", "attachment2"],
+      });
+  
+      await service.attachDraftDeletionData(mockReq);
+  
+      // Verify that attachmentsToDelete is not set
+      expect(mockReq.attachmentsToDelete).toBeUndefined();
+      // Ensure that with no attachments to delete, parentId is not set
+      expect(mockReq.parentId).toBeUndefined();
+    });
+
+    it("should not set parentId if folderId is not retrieved", async () => {
+      const attachmentsToDelete = ["attachment1", "attachment2"];
+      
+      // Mock behavior to simulate presence of attachments to delete
+      getURLsToDeleteFromDraftAttachments.mockResolvedValueOnce(attachmentsToDelete);
+      
+      // Both arrays should be of the same length to trigger folderId fetch logic
+      mockReq.diff.mockResolvedValueOnce({
+        attachments: ["attachment1", "attachment2"],
+      });
+  
+      // Simulate fetching a token, but folder ID fetch returns falsy
+      fetchAccessToken.mockResolvedValueOnce("mocked_token");
+      getFolderIdByPath.mockResolvedValueOnce(null); // Falsy value to test this situation
+  
+      await service.attachDraftDeletionData(mockReq);
+  
+      // Ensure parentId wasn't set since folderId is falsy
+      expect(mockReq.parentId).toBeUndefined();
+    });
+  });
+
   describe("registerUpdateHandlers", () => {
     let mockSrv;
     let service;
@@ -1579,7 +1694,7 @@ describe("SDMAttachmentsService", () => {
       service.registerUpdateHandlers(mockSrv, "entity", "target");
       expect(mockSrv.after).toHaveBeenCalledWith(
         ["DELETE", "UPDATE"],
-        "entity",
+        ["entity", undefined],
         expect.any(Function)
       );
     });


### PR DESCRIPTION
BugFix: Discard of drafts was not cleaning up the attachments from DI.

List of scenarios tested on cloud:

Create an entity, Upload multiple attachments, Discard drafts. => Success. Entity & all it's attachments are deleted.
Create an entity, Upload multiple attachments, Create, Edit, Upload New attachments, Discard drafts => Success. Newly added attachments are deleted.
Create an entity, Upload attachment, Create, From Workbench create an attachment, Edit the entity & Upload same attachment. => Duplicate error.
Upload a valid attachment => Success.
Upload multiple valid attachment => Success.
Upload a duplicate attachment => Duplicate error message on UI.
Upload multiple attachments, Rename few of them & Click on create => Success.
Upload multiple attachments, Rename few of them to same name as existing & Click on create => Duplicate warning
Upload multiple attachments, Click on Create, Click on Edit, Rename few of the attachments to valid names => Success.
Upload multiple attachments, Click on Create, Click on Edit, Rename few of the attachments to duplicate names => Duplicate Warning.
Upload multiple attachments of different extensions, Read them => Success. Behaviour is as expected.
Upload multiple attachments of different extensions, Create, Read them => Success. Behaviour is as expected.
Upload multiple attachments, Click on Create, Click on Edit, Delete few attachments, Click on Create => Success.
Create an entity, Upload multiple attachments, Click on Create, Delete Entity. => Success. Entity & all it's attachments are deleted.