### PR TITLE
Bug Fix To Delete Folder On Discard of drafts

### DIFF
--- a/lib/persistence/index.js
+++ b/lib/persistence/index.js
@@ -53,10 +53,15 @@ async function getURLsToDeleteFromAttachments(deletedAttachments, attachments) {
     .where({ ID: { in: [...deletedAttachments] } });
 }
 
-async function getURLsToDeleteFromDraftAttachments(draftAttachments) {
+async function getURLsToDeleteFromDraftAttachments(ID, draftAttachments) {
+  const up_ = draftAttachments.keys.up_.keys[0].$generatedFieldName;
+  const conditions = {
+    [up_]: ID,
+    HasActiveEntity: false
+  };
   return await SELECT.from(draftAttachments)
     .columns("url")
-    .where({ HasActiveEntity: false });
+    .where(conditions);
 }
 
 async function getExistingAttachments(attachmentIDs, attachments) {

--- a/lib/sdm.js
+++ b/lib/sdm.js
@@ -292,7 +292,7 @@ module.exports = class SDMAttachmentsService extends (
   async attachDraftDeletionData(req) {
     let draftAttachments = cds.model.definitions[req.query.target.name.replace(/\.drafts$/, ".attachments.drafts")];
     if(draftAttachments)  {
-      const attachmentsToDeleteFromDraft = await getURLsToDeleteFromDraftAttachments(draftAttachments);
+      const attachmentsToDeleteFromDraft = await getURLsToDeleteFromDraftAttachments(req.data.ID, draftAttachments);
       if (attachmentsToDeleteFromDraft?.length > 0) {
         req.attachmentsToDelete = attachmentsToDeleteFromDraft;
       }

--- a/test/lib/sdm.test.js
+++ b/test/lib/sdm.test.js
@@ -1558,6 +1558,9 @@ describe("SDMAttachmentsService", () => {
             name: "testName.drafts",
           },
         },
+        data: {
+          ID: "mocked_id",
+        },
         event: "DELETE",
         user: {
           tokenInfo: {
@@ -1585,7 +1588,7 @@ describe("SDMAttachmentsService", () => {
   
       await service.attachDraftDeletionData(mockReq);
   
-      expect(getURLsToDeleteFromDraftAttachments).toHaveBeenCalledWith(mockDraftAttachments);
+      expect(getURLsToDeleteFromDraftAttachments).toHaveBeenCalledWith("mocked_id", mockDraftAttachments);
       expect(mockReq.attachmentsToDelete).toEqual(attachmentsToDelete);
       expect(mockReq.parentId).toEqual("mock_folder_id");
     });


### PR DESCRIPTION
There was a bug where if we upload few attachments and before saving the entity, if we were discarding the draft. Folder in SDM was not getting deleted. This was because of DB query we were executing earlier to check if folder needs to be deleted or not. Fixed the DB query and now the folders are also getting cleaned up

List of scenarios tested on cloud:

Create an entity, Upload multiple attachments, Discard drafts. => Success. Entity & all it's attachments are deleted.
Create an entity, Upload multiple attachments, Go back and create another entity and upload few attachments in new entity, Discard drafts => Entity & all it's attachments are deleted along with cleanup from SDM.
Create an entity, Upload multiple attachments, Create, Edit, Upload New attachments, Discard drafts => Success. Newly added attachments are deleted along with cleanup from SDM.
Upload a valid attachment => Success.
Upload multiple valid attachment => Success.
Upload a duplicate attachment => Duplicate error message on UI.
Upload multiple attachments, Rename few of them & Click on create => Success.
Upload multiple attachments, Rename few of them to same name as existing & Click on create => Duplicate warning
Upload multiple attachments, Click on Create, Click on Edit, Rename few of the attachments to valid names => Success.
Upload multiple attachments, Click on Create, Click on Edit, Rename few of the attachments to duplicate names => Duplicate Warning.
Upload multiple attachments of different extensions, Read them => Success. Behaviour is as expected.
Upload multiple attachments of different extensions, Create, Read them => Success. Behaviour is as expected.
Upload multiple attachments, Click on Create, Click on Edit, Delete few attachments, Click on Create => Success.
Create an entity, Upload multiple attachments, Click on Create, Delete Entity. => Success. Entity & all it's attachments are deleted.