### PR TITLE
Rename error msg bug

### DIFF
--- a/lib/sdm.js
+++ b/lib/sdm.js
@@ -25,7 +25,7 @@ const {
   getFolderIdForEntity,
   setRepositoryId
 } = require("../lib/persistence");
-const { duplicateDraftFileErr, emptyFileErr, renameFileErr, virusFileErr, duplicateFileErr, versionedRepositoryErr, otherFileErr } = require("./util/messageConsts");
+const { duplicateDraftFileErr, emptyFileErr, renameFileErr, virusFileErr, duplicateFileErr, versionedRepositoryErr, otherFileErr, renameOtherFilesErr } = require("./util/messageConsts");
 
 module.exports = class SDMAttachmentsService extends (
   require("@cap-js/attachments/lib/basic")
@@ -100,7 +100,7 @@ module.exports = class SDMAttachmentsService extends (
     }
   }
 
-  async rename(modifiedAttachments, token, req){
+  async rename(modifiedAttachments, token, req) {
     await this.checkRepositoryType(req);
     const failedReq = await this.onRename(
       modifiedAttachments,
@@ -108,10 +108,32 @@ module.exports = class SDMAttachmentsService extends (
       token,
       req
     );
+
+    const duplicate = failedReq.filter(attachment => 
+      attachment.typeOfError === 'duplicate'
+    );
+    const duplicateNames = duplicate.map(attachment => attachment.name);
+    const notFound = failedReq.filter(attachment => 
+      attachment.typeOfError === 'not found'
+    );
+    const notFoundNames = notFound.map(attachment => attachment.name);
+    const otherErrors = failedReq.filter(attachment => 
+      attachment.typeOfError !== 'duplicate' && attachment.typeOfError !== 'not found'
+    );
+    const otherNames = otherErrors.map(attachment => attachment.name);
+    const otherMessages = otherErrors.map(attachment => attachment.typeOfError);
+    
+
     let errorResponse = "";
-    failedReq.forEach((attachment) => {
-      errorResponse = renameFileErr([attachment.name]);
-    });
+    if (duplicateNames.length > 0) {
+      errorResponse += renameFileErr(duplicateNames, 409);
+    }
+    if (notFoundNames.length > 0) {
+      errorResponse += renameFileErr(notFoundNames, 404);
+    }
+    if (otherNames.length > 0) {
+      errorResponse += renameOtherFilesErr(otherNames, otherMessages);
+    }
     return errorResponse;
   }
 
@@ -401,8 +423,15 @@ module.exports = class SDMAttachmentsService extends (
               req.data.attachments[i] = attachmentUpdate;
             }
           }
-
-          failedReq.push({typeOfError:'duplicate',name:a.name})
+          if (response.status == 409){
+            failedReq.push({typeOfError:'duplicate',name:a.name})
+          }
+          else if (response.status == 404){
+            failedReq.push({typeOfError:'not found',name:a.prevname})
+          }
+          else{
+            failedReq.push({typeOfError:response.message,name:a.name})
+          }
         }
       })
     );

--- a/lib/sdm.js
+++ b/lib/sdm.js
@@ -17,7 +17,8 @@ const {
   checkAttachmentsToRename,
   isRepositoryVersioned,
   getConfigurations,
-  getClientCredentialsToken
+  getClientCredentialsToken,
+  isRestrictedCharactersInName
 } = require("./util/index");
 const {
   getDraftAttachments,
@@ -29,7 +30,7 @@ const {
   updateAttachmentInDraft,
   setRepositoryId
 } = require("../lib/persistence");
-const { duplicateDraftFileErr, renameFileErr, virusFileErr, duplicateFileErr, versionedRepositoryErr, otherFileErr, userDoesNotHaveRequiredScope, userNotAuthorisedError, renameOtherFilesErr } = require("./util/messageConsts");
+const { duplicateDraftFileErr, renameFileErr, virusFileErr, duplicateFileErr, versionedRepositoryErr, otherFileErr, userDoesNotHaveRequiredScope, userNotAuthorisedError, renameOtherFilesErr, nameConstrainErr } = require("./util/messageConsts");
 
 module.exports = class SDMAttachmentsService extends (
   require("@cap-js/attachments/lib/basic")
@@ -129,6 +130,14 @@ module.exports = class SDMAttachmentsService extends (
       const attachment_val = await getDraftAttachmentsForUpID(draftAttachments, req, repositoryId);
 
       if (attachment_val.length > 0) {
+        const attachmentToUpload = attachment_val.find(attachment => attachment.ID === req.data.ID);
+        const filename = attachmentToUpload ? attachmentToUpload.filename : null;
+        if (filename) {
+          const nameConstraint = isRestrictedCharactersInName(filename);
+          if (nameConstraint) {
+            req.reject(409, nameConstrainErr([filename], "Upload"));
+          }
+        }
         await this.isFileNameDuplicateInDrafts(attachment_val,req);
         const token = await fetchAccessToken(
           this.creds,
@@ -156,6 +165,9 @@ module.exports = class SDMAttachmentsService extends (
       req
     );
 
+    const restrictedCharacters = failedReq.filter(attachment =>
+      attachment.typeOfError === 'restricted characters'
+    );
     const duplicate = failedReq.filter(attachment => 
       attachment.typeOfError === 'duplicate'
     );
@@ -165,13 +177,16 @@ module.exports = class SDMAttachmentsService extends (
     );
     const notFoundNames = notFound.map(attachment => attachment.name);
     const otherErrors = failedReq.filter(attachment => 
-      attachment.typeOfError !== 'duplicate' && attachment.typeOfError !== 'not found'
+      attachment.typeOfError !== 'duplicate' && attachment.typeOfError !== 'not found' && attachment.typeOfError !== 'restricted characters'
     );
     const otherNames = otherErrors.map(attachment => attachment.name);
     const otherMessages = otherErrors.map(attachment => attachment.typeOfError);
     
 
     let errorResponse = "";
+    if (restrictedCharacters.length > 0) {
+      errorResponse += nameConstrainErr(restrictedCharacters.map(attachment => attachment.name), "Rename");
+    }
     if (duplicateNames.length > 0) {
       errorResponse += renameFileErr(duplicateNames, 409);
     }
@@ -430,29 +445,39 @@ module.exports = class SDMAttachmentsService extends (
 
     await Promise.all(
       modifiedAttachments.map(async (a) => {
-        const response = await renameAttachment(
-          a,
-          credentials,
-          token
-        );
+        if (isRestrictedCharactersInName(a.name)) {
+          failedReq.push({typeOfError:'restricted characters',name:a.name});
+          const attachmentData = await this.getAttachementDataInSDM(this.creds.uri, token, a.url);
+          const filenameInSDM = attachmentData.filename;
+          const attachment = req.data.attachments.find(element => element.ID === a.ID)
+          if (attachment) {
+            attachment.filename = filenameInSDM;
+          }
+        } else {
+          const response = await renameAttachment(
+            a,
+            credentials,
+            token
+          );
 
-        if (response.status != 200) {
-          //modify req.data.attachments
-          for(let i = 0; i < req.data.attachments.length; i++) {
-            let attachmentUpdate = req.data.attachments[i];
-            if(a.ID == attachmentUpdate.ID){
-              attachmentUpdate.filename = a.prevname;
-              req.data.attachments[i] = attachmentUpdate;
+          if (response.status != 200) {
+            //modify req.data.attachments
+            for(let i = 0; i < req.data.attachments.length; i++) {
+              let attachmentUpdate = req.data.attachments[i];
+              if(a.ID == attachmentUpdate.ID){
+                attachmentUpdate.filename = a.prevname;
+                req.data.attachments[i] = attachmentUpdate;
+              }
             }
-          }
-          if (response.status == 409){
-            failedReq.push({typeOfError:'duplicate',name:a.name})
-          }
-          else if (response.status == 404){
-            failedReq.push({typeOfError:'not found',name:a.prevname})
-          }
-          else{
-            failedReq.push({typeOfError:response.message,name:a.name})
+            if (response.status == 409){
+              failedReq.push({typeOfError:'duplicate',name:a.name})
+            }
+            else if (response.status == 404){
+              failedReq.push({typeOfError:'not found',name:a.prevname})
+            }
+            else{
+              failedReq.push({typeOfError:response.message,name:a.name})
+            }
           }
         }
       })

--- a/lib/sdm.js
+++ b/lib/sdm.js
@@ -18,7 +18,8 @@ const {
   isRepositoryVersioned,
   getConfigurations,
   getClientCredentialsToken,
-  isRestrictedCharactersInName
+  isRestrictedCharactersInName,
+  getStatusCondition
 } = require("./util/index");
 const {
   getDraftAttachments,
@@ -186,10 +187,10 @@ module.exports = class SDMAttachmentsService extends (
       errorResponse += nameConstrainErr(restrictedCharacters.map(attachment => attachment.name), "Rename");
     }
     if (duplicateNames.length > 0) {
-      errorResponse += renameFileErr(duplicateNames, 409);
+      errorResponse += renameFileErr(duplicateNames, getStatusCondition(409));
     }
     if (notFoundNames.length > 0) {
-      errorResponse += renameFileErr(notFoundNames, 404);
+      errorResponse += renameFileErr(notFoundNames, getStatusCondition(404));
     }
     if (otherNames.length > 0) {
       errorResponse += renameOtherFilesErr(otherNames, otherMessages);

--- a/lib/util/index.js
+++ b/lib/util/index.js
@@ -137,10 +137,16 @@ async function checkAttachmentsToRename(attachment_val_rename, attachmentIDs, at
   return modifiedAttachments
 }
 
+function isRestrictedCharactersInName(filename) {
+  const regex = /[\/\\]/;
+  return regex.test(filename);
+}
+
 module.exports = {
   fetchAccessToken,
   getConfigurations,
   checkAttachmentsToRename,
   isRepositoryVersioned,
-  getClientCredentialsToken
+  getClientCredentialsToken,
+  isRestrictedCharactersInName
 };

--- a/lib/util/index.js
+++ b/lib/util/index.js
@@ -138,7 +138,7 @@ async function checkAttachmentsToRename(attachment_val_rename, attachmentIDs, at
 }
 
 function isRestrictedCharactersInName(filename) {
-  const regex = /[\/\\]/;
+  const regex = /[/\\]/;
   return regex.test(filename);
 }
 

--- a/lib/util/index.js
+++ b/lib/util/index.js
@@ -142,11 +142,20 @@ function isRestrictedCharactersInName(filename) {
   return regex.test(filename);
 }
 
+function getStatusCondition(statusCode) {
+  if (statusCode === 404) {
+    return "don't";
+  } else if (statusCode === 409) {
+    return "already";
+  }
+}
+
 module.exports = {
   fetchAccessToken,
   getConfigurations,
   checkAttachmentsToRename,
   isRepositoryVersioned,
   getClientCredentialsToken,
-  isRestrictedCharactersInName
+  isRestrictedCharactersInName,
+  getStatusCondition
 };

--- a/lib/util/messageConsts.js
+++ b/lib/util/messageConsts.js
@@ -10,7 +10,14 @@ module.exports.duplicateFileErr = (duplicateFiles) => {
 };
 module.exports.renameFileErr = (duplicateFiles, statusCode) => {
   const bulletPoints = duplicateFiles.map(file => `• ${file}`).join('\n');
-  const alreadyOrDont = statusCode === 404 ? "don't" : statusCode === 409 ? "already" : "unknown";
+  let alreadyOrDont;
+  if (statusCode === 404) {
+    alreadyOrDont = "don't";
+  } else if (statusCode === 409) {
+    alreadyOrDont = "already";
+  } else {
+    alreadyOrDont = "unknown";
+  }
   return `The following files could not be renamed as they ${alreadyOrDont} exist:\n${bulletPoints}\n`;
 };
 module.exports.renameOtherFilesErr = (otherFiles, otherFileMessages) => {
@@ -25,3 +32,9 @@ module.exports.versionedRepositoryErr = 'Attachments are not supported for a ver
 module.exports.userNotAuthorisedError  = 'You do not have the required permissions to upload attachments. Please contact your administrator for access.';
 module.exports.userDoesNotHaveRequiredScope = 'User does not have the required scope';
 module.exports.errorMessage = 'An error occurred';
+module.exports.nameConstrainErr = (fileNameWithRestrictedCharacters, operation) => {
+  const prefixMessage = `${operation} unsuccessful. The following filename(s) contain unsupported characters (/, \\). \n\n`;
+  const bulletPoints = fileNameWithRestrictedCharacters.map(file => `\t• ${file}`).join('\n');
+  const message = `${prefixMessage}${bulletPoints}\n\nRename the file(s) and try again.\n`;
+  return message;
+};

--- a/lib/util/messageConsts.js
+++ b/lib/util/messageConsts.js
@@ -8,20 +8,12 @@ module.exports.duplicateFileErr = (duplicateFiles) => {
   const bulletPoints = duplicateFiles.map(file => `• ${file}`).join('\n');
   return `The following files could not be uploaded as they already exist:\n${bulletPoints}\n`;
 };
-module.exports.renameFileErr = (duplicateFiles, statusCode) => {
+module.exports.renameFileErr = (duplicateFiles, statusCondition) => {
   const bulletPoints = duplicateFiles.map(file => `• ${file}`).join('\n');
-  let alreadyOrDont;
-  if (statusCode === 404) {
-    alreadyOrDont = "don't";
-  } else if (statusCode === 409) {
-    alreadyOrDont = "already";
-  } else {
-    alreadyOrDont = "unknown";
+  if (statusCondition === "don't") {
+    return `The following files could not be renamed as they ${statusCondition} exist:\n${bulletPoints}\n\nDelete and upload the files again.\n`;
   }
-  if (statusCode === 404) {
-    return `The following files could not be renamed as they ${alreadyOrDont} exist:\n${bulletPoints}\n\nDelete and upload the files again.\n`;
-  }
-  return `The following files could not be renamed as they ${alreadyOrDont} exist:\n${bulletPoints}\n`;
+  return `The following files could not be renamed as they ${statusCondition} exist:\n${bulletPoints}\n`;
 };
 module.exports.renameOtherFilesErr = (otherFiles, otherFileMessages) => {
   const bulletPoints = otherFiles.map((file, index) => `• ${file} : ${otherFileMessages[index]}`).join('\n');

--- a/lib/util/messageConsts.js
+++ b/lib/util/messageConsts.js
@@ -18,6 +18,9 @@ module.exports.renameFileErr = (duplicateFiles, statusCode) => {
   } else {
     alreadyOrDont = "unknown";
   }
+  if (statusCode === 404) {
+    return `The following files could not be renamed as they ${alreadyOrDont} exist:\n${bulletPoints}\n\nDelete and upload the files again.\n`;
+  }
   return `The following files could not be renamed as they ${alreadyOrDont} exist:\n${bulletPoints}\n`;
 };
 module.exports.renameOtherFilesErr = (otherFiles, otherFileMessages) => {

--- a/lib/util/messageConsts.js
+++ b/lib/util/messageConsts.js
@@ -10,9 +10,14 @@ module.exports.duplicateFileErr = (duplicateFiles) => {
   const bulletPoints = duplicateFiles.map(file => `• ${file}`).join('\n');
   return `The following files could not be uploaded as they already exist:\n${bulletPoints}\n`;
 };
-module.exports.renameFileErr = (duplicateFiles) => {
+module.exports.renameFileErr = (duplicateFiles, statusCode) => {
   const bulletPoints = duplicateFiles.map(file => `• ${file}`).join('\n');
-  return `The following files could not be renamed as they already exist:\n${bulletPoints}\n`;
+  const alreadyOrDont = statusCode === 404 ? "don't" : statusCode === 409 ? "already" : "unknown";
+  return `The following files could not be renamed as they ${alreadyOrDont} exist:\n${bulletPoints}\n`;
+};
+module.exports.renameOtherFilesErr = (otherFiles, otherFileMessages) => {
+  const bulletPoints = otherFiles.map((file, index) => `• ${file} : ${otherFileMessages[index]}`).join('\n');
+  return `The following files could not be renamed:\n${bulletPoints}\n`;
 };
 module.exports.otherFileErr = (otherFiles) => {
   const message = otherFiles.map(file => `${file}`).join('\n');

--- a/test/lib/sdm.test.js
+++ b/test/lib/sdm.test.js
@@ -5,7 +5,8 @@ const {
   checkAttachmentsToRename,
   getConfigurations,
   isRepositoryVersioned,
-  getClientCredentialsToken
+  getClientCredentialsToken,
+  isRestrictedCharactersInName
 } = require("../../lib/util");
 const {
   getDraftAttachments,
@@ -35,7 +36,10 @@ const {
   otherFileErr,
   userNotAuthorisedError,
   userDoesNotHaveRequiredScope,
-  versionedRepositoryErr
+  versionedRepositoryErr,
+  nameConstrainErr,
+  renameFileErr,
+  renameOtherFilesErr
 } = require("../../lib/util/messageConsts");
 
 jest.mock("@cap-js/attachments/lib/basic", () => class {});
@@ -56,7 +60,8 @@ jest.mock("../../lib/util", () => ({
   checkAttachmentsToRename: jest.fn(),
   getConfigurations: jest.fn(),
   isRepositoryVersioned: jest.fn(),
-  getClientCredentialsToken: jest.fn()
+  getClientCredentialsToken: jest.fn(),
+  isRestrictedCharactersInName: jest.fn()
 }));
 jest.mock("../../lib/handler", () => ({
   deleteAttachmentsOfFolder: jest.fn(),
@@ -497,7 +502,7 @@ describe("SDMAttachmentsService", () => {
           status: 403,
           message: "Unauthorized"
         })
-      await service.draftSaveHandler(req);
+      await service.renameHandler(req);
 
       expect(renameSpy).toBeCalled();
     });
@@ -656,6 +661,41 @@ describe("SDMAttachmentsService", () => {
   
       expect(service.isFileNameDuplicateInDrafts).not.toHaveBeenCalled();
       expect(service.create).not.toHaveBeenCalled();
+    });
+    test('should reject when filename contains restricted characters', async () => {
+      const draftAttachments = [];
+      const req = { data: { content: 'some content', ID: '12345' }, target: draftAttachments, user: { tokenInfo: { getTokenValue: jest.fn().mockReturnValue('mockTokenValue') } }, reject: jest.fn() };
+      const token = 'token123';
+      const attachment_val = [
+        { HasActiveEntity: false, ID: '12345', filename: 'invalid/name' },
+        { HasActiveEntity: true, ID: '67890' },
+      ];
+      getDraftAttachmentsForUpID.mockResolvedValue(attachment_val);
+      fetchAccessToken.mockResolvedValue(token);
+      isRestrictedCharactersInName.mockReturnValue(true);
+  
+      await service.draftSaveHandler(req);
+  
+      expect(req.reject).toHaveBeenCalledWith(409, nameConstrainErr(['invalid/name'], "Upload"));
+    });
+  
+    test('should not reject when filename does not contain restricted characters', async () => {
+      const draftAttachments = [];
+      const req = { data: { content: 'some content', ID: '12345' }, target: draftAttachments, user: { tokenInfo: { getTokenValue: jest.fn().mockReturnValue('mockTokenValue') } }, reject: jest.fn() };
+      const token = 'token123';
+      const attachment_val = [
+        { HasActiveEntity: false, ID: '12345', filename: 'validname' },
+        { HasActiveEntity: true, ID: '67890' },
+      ];
+      getDraftAttachmentsForUpID.mockResolvedValue(attachment_val);
+      fetchAccessToken.mockResolvedValue(token);
+      isRestrictedCharactersInName.mockReturnValue(false);
+  
+      await service.draftSaveHandler(req);
+  
+      expect(req.reject).not.toHaveBeenCalled();
+      expect(service.create).toHaveBeenCalledWith([{ ...attachment_val[0], content: 'some content' }], draftAttachments, req, token);
+      expect(req.data.content).toBeNull();
     });
   });
 
@@ -1214,7 +1254,7 @@ describe("SDMAttachmentsService", () => {
       expect(mockReq.info).not.toBeCalled();
     })
 
-    it("should handle failure in onRename", async () => {
+    it("should handle failure in onRename with duplicate error", async () => {
       const token = "token";
       const modifiedAttachments = [];
 
@@ -1226,8 +1266,78 @@ describe("SDMAttachmentsService", () => {
         mockReq
       );
 
-      expect(response).toBe("The following files could not be renamed as they already exist:\n• renameduplicate\n");
+      expect(response).toBe(renameFileErr(["renameduplicate"], 409));
     })
+
+    it("should handle failure in onRename with not found error", async () => {
+      const token = "token";
+      const modifiedAttachments = [];
+  
+      service.onRename = jest.fn().mockResolvedValue([{typeOfError:'not found',name:"renameNotFound"}]);
+  
+      const response = await service.rename(
+        modifiedAttachments,
+        token,
+        mockReq
+      );
+  
+      expect(response).toBe(renameFileErr(["renameNotFound"], 404));
+    });
+  
+    it("should handle failure in onRename with restricted characters error", async () => {
+      const token = "token";
+      const modifiedAttachments = [];
+  
+      service.onRename = jest.fn().mockResolvedValue([{typeOfError:'restricted characters',name:"renameRestricted"}]);
+  
+      const response = await service.rename(
+        modifiedAttachments,
+        token,
+        mockReq
+      );
+  
+      expect(response).toBe(nameConstrainErr(["renameRestricted"], "Rename"));
+    });
+  
+    it("should handle failure in onRename with other errors", async () => {
+      const token = "token";
+      const modifiedAttachments = [];
+  
+      service.onRename = jest.fn().mockResolvedValue([{typeOfError:'some other error',name:"renameOtherError"}]);
+  
+      const response = await service.rename(
+        modifiedAttachments,
+        token,
+        mockReq
+      );
+  
+      expect(response).toBe(renameOtherFilesErr(["renameOtherError"],["some other error"]));
+    });
+
+    it("should handle multiple errors in onRename", async () => {
+      const token = "token";
+      const modifiedAttachments = [];
+  
+      service.onRename = jest.fn().mockResolvedValue([
+        {typeOfError:'duplicate', name:"renameduplicate"},
+        {typeOfError:'not found', name:"renameNotFound"},
+        {typeOfError:'restricted characters', name:"renameRestricted"},
+        {typeOfError:'some other error', name:"renameOtherError"}
+      ]);
+  
+      const response = await service.rename(
+        modifiedAttachments,
+        token,
+        mockReq
+      );
+
+      const expectedResponse = 
+        nameConstrainErr(["renameRestricted"], "Rename") +
+        renameFileErr(["renameduplicate"], 409) +
+        renameFileErr(["renameNotFound"], 404) +
+        renameOtherFilesErr(["renameOtherError"], ["some other error"])
+      expect(response).toBe(expectedResponse);
+    });
   });
 
   describe('onCreate', () => {
@@ -1302,26 +1412,39 @@ describe("SDMAttachmentsService", () => {
     let service;
     beforeEach(() => {
       jest.clearAllMocks();
+      jest.resetAllMocks();
       service = new SDMAttachmentsService();
+      service.creds = { uri: 'sampleUri' };
     });
     it("should return empty array if no attachments fail", async () => {
-      const modifiedAttachments = [{name:"name"}];
+      const modifiedAttachments = [{ name: "name", ID: "someID", url: "someURL" }];
       const credentials = {};
       const token = "token";
-
+      const req = {
+        data: {
+          attachments: [
+            {
+              ID: 'someID',
+              filename: 'someFilename'
+            }
+          ]
+        }
+      };
+  
+      isRestrictedCharactersInName.mockReturnValue(false);
       renameAttachment.mockResolvedValueOnce({
         status: 200,
-        response : {
-          data: {
-            message: 'error'
-          }
+        data: {
+          message: 'success'
         }
-      });
-
+      })
+      service.getAttachementDataInSDM = jest.fn().mockResolvedValue({ filename: 'someFilename' });
+  
       const result = await service.onRename(
         modifiedAttachments,
         credentials,
         token,
+        req
       );
       expect(result).toEqual([]);
     });
@@ -1366,6 +1489,7 @@ describe("SDMAttachmentsService", () => {
         }
       }
     
+      isRestrictedCharactersInName.mockReturnValue(false);
       renameAttachment
         .mockResolvedValueOnce({
           status: 200,
@@ -1391,6 +1515,36 @@ describe("SDMAttachmentsService", () => {
         req
       );
       expect(result).toEqual([{ "name": "attachment#2prev", "typeOfError": "not found" },{ "name": "attachment#3", "typeOfError": "duplicate" },{ "name": "attachment#4", "typeOfError": "Unauthorized" }]);
+    });
+
+    it("should handle restricted characters in filename and update filename in request", async () => {
+      const modifiedAttachments = [{ name: "invalid/name", ID: "someID", url: "someURL" }];
+      const credentials = {};
+      const token = "token";
+      const req = {
+        data: {
+          attachments: [
+            {
+              ID: 'someID',
+              filename: 'someFilename'
+            }
+          ]
+        }
+      };
+  
+      isRestrictedCharactersInName.mockReturnValue(true);
+      service.getAttachementDataInSDM = jest.fn().mockResolvedValue({ filename: 'updatedFilename' });
+  
+      const result = await service.onRename(
+        modifiedAttachments,
+        credentials,
+        token,
+        req
+      );
+  
+      expect(result).toEqual([{ typeOfError: 'restricted characters', name: 'invalid/name' }]);
+      expect(service.getAttachementDataInSDM).toHaveBeenCalledWith('sampleUri', token, 'someURL');
+      expect(req.data.attachments[0].filename).toBe('updatedFilename');
     });
   });
 

--- a/test/lib/sdm.test.js
+++ b/test/lib/sdm.test.js
@@ -495,7 +495,7 @@ describe("SDMAttachmentsService", () => {
           status: 403,
           message: "Unauthorized"
         })
-      await service.draftSaveHandler(mockReq);
+      await service.draftSaveHandler(req);
 
       expect(renameSpy).toBeCalled();
     });

--- a/test/lib/sdm.test.js
+++ b/test/lib/sdm.test.js
@@ -466,67 +466,67 @@ cds.context = {
       expect(renameSpy).toBeCalled();
     });
 
-    // it("should throw correct error message for all rename scenarios in DI", async () => {
-    //   service.rename = jest.fn().mockResolvedValueOnce([]);
-    //   const renameSpy = jest.spyOn(service, "rename");
-    //   getDraftAttachments.mockResolvedValueOnce([
-    //     {
-    //       'ID': 'id1',
-    //       'filename': 'attachment1',
-    //       'HasActiveEntity' : true
-    //     },
-    //     {
-    //       'ID': 'id2',
-    //       'filename': 'attachment2',
-    //       'HasActiveEntity' : true
-    //     },
-    //     {
-    //       'ID': 'id3',
-    //       'filename': 'attachment3',
-    //       'HasActiveEntity' : true
-    //     },
-    //   ]);
-    //   const modifiedAttachments = [
-    //     {
-    //       ID: 'id1',
-    //       url: 'url1',
-    //       name: 'attachment1new',
-    //       prevname: 'attachment1',
-    //       folderId: 'folder1'
-    //     },
-    //     {
-    //       ID: 'id2',
-    //       url: 'url2',
-    //       name: 'attachment2new',
-    //       prevname: 'attachment2',
-    //       folderId: 'folder1'
-    //     },
-    //     {
-    //       ID: 'id3',
-    //       url: 'url3',
-    //       name: 'attachment3new',
-    //       prevname: 'attachment3',
-    //       folderId: 'folder1'
-    //     }
-    //   ];
-    //   checkAttachmentsToRename.mockResolvedValueOnce(modifiedAttachments);
-    //   renameAttachment
-    //     .mockResolvedValueOnce({
-    //       status: 404,
-    //       message: "File not found"
-    //     })
-    //     .mockResolvedValueOnce({
-    //       status: 409,
-    //       message: "File already exists"
-    //     })
-    //     .mockResolvedValueOnce({
-    //       status: 403,
-    //       message: "Unauthorized"
-    //     })
-    //   await service.draftSaveHandler(mockReq);
+    it("should throw correct error message for all rename scenarios in DI", async () => {
+      service.rename = jest.fn().mockResolvedValueOnce([]);
+      const renameSpy = jest.spyOn(service, "rename");
+      getDraftAttachments.mockResolvedValueOnce([
+        {
+          'ID': 'id1',
+          'filename': 'attachment1',
+          'HasActiveEntity' : true
+        },
+        {
+          'ID': 'id2',
+          'filename': 'attachment2',
+          'HasActiveEntity' : true
+        },
+        {
+          'ID': 'id3',
+          'filename': 'attachment3',
+          'HasActiveEntity' : true
+        },
+      ]);
+      const modifiedAttachments = [
+        {
+          ID: 'id1',
+          url: 'url1',
+          name: 'attachment1new',
+          prevname: 'attachment1',
+          folderId: 'folder1'
+        },
+        {
+          ID: 'id2',
+          url: 'url2',
+          name: 'attachment2new',
+          prevname: 'attachment2',
+          folderId: 'folder1'
+        },
+        {
+          ID: 'id3',
+          url: 'url3',
+          name: 'attachment3new',
+          prevname: 'attachment3',
+          folderId: 'folder1'
+        }
+      ];
+      checkAttachmentsToRename.mockResolvedValueOnce(modifiedAttachments);
+      renameAttachment
+        .mockResolvedValueOnce({
+          status: 404,
+          message: "File not found"
+        })
+        .mockResolvedValueOnce({
+          status: 409,
+          message: "File already exists"
+        })
+        .mockResolvedValueOnce({
+          status: 403,
+          message: "Unauthorized"
+        })
+      await service.draftSaveHandler(mockReq);
 
-    //   expect(renameSpy).toBeCalled();
-    // });
+      expect(renameSpy).toBeCalled();
+    });
   });
 
   describe("Test filterAttachments", () => {

--- a/test/lib/sdm.test.js
+++ b/test/lib/sdm.test.js
@@ -465,6 +465,68 @@ cds.context = {
       expect(createSpy).toBeCalled();
       expect(renameSpy).toBeCalled();
     });
+
+    // it("should throw correct error message for all rename scenarios in DI", async () => {
+    //   service.rename = jest.fn().mockResolvedValueOnce([]);
+    //   const renameSpy = jest.spyOn(service, "rename");
+    //   getDraftAttachments.mockResolvedValueOnce([
+    //     {
+    //       'ID': 'id1',
+    //       'filename': 'attachment1',
+    //       'HasActiveEntity' : true
+    //     },
+    //     {
+    //       'ID': 'id2',
+    //       'filename': 'attachment2',
+    //       'HasActiveEntity' : true
+    //     },
+    //     {
+    //       'ID': 'id3',
+    //       'filename': 'attachment3',
+    //       'HasActiveEntity' : true
+    //     },
+    //   ]);
+    //   const modifiedAttachments = [
+    //     {
+    //       ID: 'id1',
+    //       url: 'url1',
+    //       name: 'attachment1new',
+    //       prevname: 'attachment1',
+    //       folderId: 'folder1'
+    //     },
+    //     {
+    //       ID: 'id2',
+    //       url: 'url2',
+    //       name: 'attachment2new',
+    //       prevname: 'attachment2',
+    //       folderId: 'folder1'
+    //     },
+    //     {
+    //       ID: 'id3',
+    //       url: 'url3',
+    //       name: 'attachment3new',
+    //       prevname: 'attachment3',
+    //       folderId: 'folder1'
+    //     }
+    //   ];
+    //   checkAttachmentsToRename.mockResolvedValueOnce(modifiedAttachments);
+    //   renameAttachment
+    //     .mockResolvedValueOnce({
+    //       status: 404,
+    //       message: "File not found"
+    //     })
+    //     .mockResolvedValueOnce({
+    //       status: 409,
+    //       message: "File already exists"
+    //     })
+    //     .mockResolvedValueOnce({
+    //       status: 403,
+    //       message: "Unauthorized"
+    //     })
+    //   await service.draftSaveHandler(mockReq);
+
+    //   expect(renameSpy).toBeCalled();
+    // });
   });
 
   describe("Test filterAttachments", () => {
@@ -1248,7 +1310,7 @@ cds.context = {
     });
 
     it("should return failed request messages if rename fails for some attachments", async () => {
-      const modifiedAttachments = [{ name: "attachment#1", id:"id1" }, { name: "attachment#2", id:"id2" }, { name: "attachment#3", id:"id3" }];
+      const modifiedAttachments = [{ name: "attachment#1", id:"id1" }, { name: "attachment#2", id:"id2", prevname: "attachment#2prev" }, { name: "attachment#3", id:"id3" }, { name: "attachment#4", id:"id4" }];
       const credentials = {};
       const token = "token";
       const req = {
@@ -1256,15 +1318,20 @@ cds.context = {
           attachments: [
             {
               id: "id1",
-              filename: "attachment#1"
+              name: "attachment#1"
             },
             {
               id: "id2",
-              filename: "attachment#2"
+              name: "attachment#2",
+              prevname: "attachment#2prev"
             },
             {
               id: "id3",
-              filename: "attachment#3"
+              name: "attachment#3"
+            },
+            {
+              id: "id4",
+              name: "attachment#4"
             }
           ]
         }
@@ -1276,11 +1343,17 @@ cds.context = {
           data: { succinctProperties: { "cmis:objectId": "url" } },
         })
         .mockResolvedValueOnce({
-          response: { data: { message: "Error occurred with Id null" }, status : 400 }
+          status: 404,
+          message: "File not found"
         })
         .mockResolvedValueOnce({
-          response: { data: { message: "Error occurred" }, status : 400 }
-        });
+          status: 409,
+          message: "File already exists"
+        })
+        .mockResolvedValueOnce({
+          status: 403,
+          message: "Unauthorized"
+        })
 
       const result = await service.onRename(
         modifiedAttachments,
@@ -1288,7 +1361,7 @@ cds.context = {
         token,
         req
       );
-      expect(result).toEqual([{ "name": "attachment#2", "typeOfError": "duplicate" },{ "name": "attachment#3", "typeOfError": "duplicate" }]);
+      expect(result).toEqual([{ "name": "attachment#2prev", "typeOfError": "not found" },{ "name": "attachment#3", "typeOfError": "duplicate" },{ "name": "attachment#4", "typeOfError": "Unauthorized" }]);
     });
   });
 

--- a/test/lib/sdm.test.js
+++ b/test/lib/sdm.test.js
@@ -6,7 +6,8 @@ const {
   getConfigurations,
   isRepositoryVersioned,
   getClientCredentialsToken,
-  isRestrictedCharactersInName
+  isRestrictedCharactersInName,
+  getStatusCondition
 } = require("../../lib/util");
 const {
   getDraftAttachments,
@@ -61,7 +62,8 @@ jest.mock("../../lib/util", () => ({
   getConfigurations: jest.fn(),
   isRepositoryVersioned: jest.fn(),
   getClientCredentialsToken: jest.fn(),
-  isRestrictedCharactersInName: jest.fn()
+  isRestrictedCharactersInName: jest.fn(),
+  getStatusCondition: jest.fn()
 }));
 jest.mock("../../lib/handler", () => ({
   deleteAttachmentsOfFolder: jest.fn(),
@@ -1249,7 +1251,8 @@ describe("SDMAttachmentsService", () => {
     it("should handle failure in onRename with duplicate error", async () => {
       const token = "token";
       const modifiedAttachments = [];
-
+      
+      getStatusCondition.mockReturnValueOnce("already");
       service.onRename = jest.fn().mockResolvedValue([{typeOfError:'duplicate',name:"renameduplicate"}]);
 
       response = await service.rename(
@@ -1258,13 +1261,14 @@ describe("SDMAttachmentsService", () => {
         mockReq
       );
 
-      expect(response).toBe(renameFileErr(["renameduplicate"], 409));
+      expect(response).toBe(renameFileErr(["renameduplicate"], "already"));
     })
 
     it("should handle failure in onRename with not found error", async () => {
       const token = "token";
       const modifiedAttachments = [];
   
+      getStatusCondition.mockReturnValueOnce("don't");
       service.onRename = jest.fn().mockResolvedValue([{typeOfError:'not found',name:"renameNotFound"}]);
   
       const response = await service.rename(
@@ -1273,7 +1277,7 @@ describe("SDMAttachmentsService", () => {
         mockReq
       );
   
-      expect(response).toBe(renameFileErr(["renameNotFound"], 404));
+      expect(response).toBe(renameFileErr(["renameNotFound"], "don't"));
     });
   
     it("should handle failure in onRename with restricted characters error", async () => {
@@ -1310,11 +1314,20 @@ describe("SDMAttachmentsService", () => {
       const token = "token";
       const modifiedAttachments = [];
   
+      // Provide behavior specific to this test
+      getStatusCondition.mockImplementation((statusCode) => {
+        if (statusCode === 404) {
+          return "don't";
+        } else if (statusCode === 409) {
+          return "already";
+        }
+      });
+  
       service.onRename = jest.fn().mockResolvedValue([
-        {typeOfError:'duplicate', name:"renameduplicate"},
-        {typeOfError:'not found', name:"renameNotFound"},
-        {typeOfError:'restricted characters', name:"renameRestricted"},
-        {typeOfError:'some other error', name:"renameOtherError"}
+        { typeOfError: 'duplicate', name: "renameduplicate" },
+        { typeOfError: 'not found', name: "renameNotFound" },
+        { typeOfError: 'restricted characters', name: "renameRestricted" },
+        { typeOfError: 'some other error', name: "renameOtherError" }
       ]);
   
       const response = await service.rename(
@@ -1322,12 +1335,13 @@ describe("SDMAttachmentsService", () => {
         token,
         mockReq
       );
-
+  
       const expectedResponse = 
         nameConstrainErr(["renameRestricted"], "Rename") +
-        renameFileErr(["renameduplicate"], 409) +
-        renameFileErr(["renameNotFound"], 404) +
-        renameOtherFilesErr(["renameOtherError"], ["some other error"])
+        renameFileErr(["renameduplicate"], "already") +
+        renameFileErr(["renameNotFound"], "don't") +
+        renameOtherFilesErr(["renameOtherError"], ["some other error"]);
+  
       expect(response).toBe(expectedResponse);
     });
   });

--- a/test/lib/util/index.test.js
+++ b/test/lib/util/index.test.js
@@ -8,7 +8,8 @@ const {
   checkAttachmentsToRename,
   isRepositoryVersioned,
   getClientCredentialsToken,
-  isRestrictedCharactersInName
+  isRestrictedCharactersInName,
+  getStatusCondition,
 } = require("../../../lib/util/index");
 
 const cds = require("@sap/cds");
@@ -433,6 +434,23 @@ describe("util", () => {
       const filename = "valid_filename";
       const result = isRestrictedCharactersInName(filename);
       expect(result).toBe(false);
+    });
+  });
+
+  describe('getStatusCondition', () => {
+    it('should return "don\'t" for status code 404', () => {
+      const result = getStatusCondition(404);
+      expect(result).toBe("don't");
+    });
+  
+    it('should return "already" for status code 409', () => {
+      const result = getStatusCondition(409);
+      expect(result).toBe("already");
+    });
+  
+    it('should return undefined for unknown status code', () => {
+      const result = getStatusCondition(500); // Example of a status that isn't handled specifically
+      expect(result).toBeUndefined();
     });
   });
 });

--- a/test/lib/util/index.test.js
+++ b/test/lib/util/index.test.js
@@ -7,7 +7,8 @@ const {
   getConfigurations,
   checkAttachmentsToRename,
   isRepositoryVersioned,
-  getClientCredentialsToken
+  getClientCredentialsToken,
+  isRestrictedCharactersInName
 } = require("../../../lib/util/index");
 
 const cds = require("@sap/cds");
@@ -400,6 +401,38 @@ describe("util", () => {
       await checkAttachmentsToRename(attachment_val_rename, attachmentIDs, attachments)
 
       expect(getExistingAttachments).toBeCalled();
+    });
+  });
+
+  describe("isRestrictedCharactersInName", () => {
+    it("should return true if the filename contains a forward slash", () => {
+      const filename = "file/name";
+      const result = isRestrictedCharactersInName(filename);
+      expect(result).toBe(true);
+    });
+  
+    it("should return true if the filename contains a backslash", () => {
+      const filename = "file\\name";
+      const result = isRestrictedCharactersInName(filename);
+      expect(result).toBe(true);
+    });
+  
+    it("should return false if the filename does not contain restricted characters", () => {
+      const filename = "filename";
+      const result = isRestrictedCharactersInName(filename);
+      expect(result).toBe(false);
+    });
+  
+    it("should return false if the filename is empty", () => {
+      const filename = "";
+      const result = isRestrictedCharactersInName(filename);
+      expect(result).toBe(false);
+    });
+  
+    it("should return false if the filename contains only valid characters", () => {
+      const filename = "valid_filename";
+      const result = isRestrictedCharactersInName(filename);
+      expect(result).toBe(false);
     });
   });
 });


### PR DESCRIPTION
Jira: https://jira.tools.sap/browse/SDMEXT-960 & Rename error msg Internal Bug.

With this PR, we handle special characters in attachment names. Now if users will upload/rename attachments with special characters(/, \) in filename, they will be prompted with error message inncase of upload and warning in case of rename.

Apart from this there was an internal bug for below scenario in rename, which too is fixed now

Create an entity and upload an attachment in nodejs. 
Remove this attachment from the backend directly.
The attachment still appears on UI and when we try to rename it the UI throws duplicate error

Uploading attachment with restricted character
<img width="1728" alt="Screenshot 2025-03-18 at 11 56 48 AM" src="https://github.com/user-attachments/assets/e6d0ef4f-c1d9-4563-9f7a-800b613fc39e" />
Renaming attachment with restricted character
<img width="568" alt="Screenshot 2025-03-18 at 11 57 58 AM" src="https://github.com/user-attachments/assets/aaef087b-3450-40e5-bffd-1955c11009ec" />
Renaming a file deleted from backend
<img width="405" alt="Screenshot 2025-03-18 at 12 03 50 PM" src="https://github.com/user-attachments/assets/55c853c0-0203-4a3b-bade-2ce9ed29b012" />
