### PR TITLE
Remove rel1.3.1 from change log

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,6 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 - Attachment stored in SDM as soon as user uploads the attachment.
 - Capability to configure repository id from user provided variables.
 
-## VERSION 1.3.1
-
 ### Changed
 - Attachments usage changed to using { sap.attachments.Attachments } from '@cap-js/attachments'.
 


### PR DESCRIPTION
There was a patch release v1.3.1 planned after attachments 2.0.0 release. Although due to Blackduck High security vulnerability, it is delayed and we will be releasing the change in minor release v1.4.0. This PR removes Release v1.3.1 section from ChangeLog.