### PR TITLE
Revert SDM namespace & update attachments to version2.0.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ If you want to use the version under development follow the below steps:
 
 ```
 using { sap.capire.incidents as my } from './schema';
-using { sap.attachments.Attachments } from '@cap-js/sdm';
+using { Attachments } from '@cap-js/sdm';
 
 extend my.Incidents with { attachments: Composition of many Attachments }
 ```

--- a/index.cds
+++ b/index.cds
@@ -1,4 +1,3 @@
-namespace sap.attachments;
 using { sap.attachments.Attachments } from '@cap-js/attachments';
 extend aspect Attachments with {
     folderId : String @title: 'Folder ID' @readonly;

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "plugin"
   ],
   "dependencies": {
-    "@cap-js/attachments": "2.0.0",
+    "@cap-js/attachments": "2.0.2",
     "@sap/xssec": "^3.6.1",
     "axios": "^1.7.4",
     "node-cache": "^5.1.2"


### PR DESCRIPTION
This PR reverts the SDM plugins namespace changes and also updates the attachments v2.0.2