### PR TITLE
Delete draft attachment bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 - Handling of special characters in attachments name during upload and rename of attachments.
 
 ### Fixed
-- Issue with deleting attachments from SDM when the entity has not been saved once
+- Issue with deleting attachments from SDM when the entity has not been saved once.
 - Error message in case of rename when attachment is deleted from backend SDM repository.
 
 ## Version 1.4.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 - Handling of special characters in attachments name during upload and rename of attachments.
 
 ### Fixed
+- Issue with deleting attachments from SDM when the entity has not been saved once
 - Error message in case of rename when attachment is deleted from backend SDM repository.
 
 ## Version 1.4.0

--- a/lib/handler/index.js
+++ b/lib/handler/index.js
@@ -55,6 +55,32 @@ async function getRepositoryInfo(credentials, token) {
 
 async function getFolderIdByPath(req, credentials, token, attachments) {
   const up_ = attachments.keys.up_.keys[0].$generatedFieldName;
+  const { repositoryId } = getConfigurations();
+  const getFolderByPathURL =
+    credentials.uri +
+    "browser/" +
+    repositoryId +
+    "/root/" +
+    req.data[up_] +
+    "?cmisselector=object";
+  const config = {
+    headers: { Authorization: `Bearer ${token}` },
+  };
+  try {
+    const response = await axios.get(getFolderByPathURL, config);
+    return response.data.properties["cmis:objectId"].value;
+  } catch (error) {
+    let statusText = errorMessage;
+    if (error.response?.statusText) {
+      statusText = error.response.statusText;
+    }
+    console.log(statusText);
+    return null;
+  }
+}
+
+async function getFolderIdByIDAsPath(req, credentials, token, attachments) {
+  const up_ = attachments.keys.up_.keys[0].$generatedFieldName;
   const idValue = up_.split("__")[1];
   const { repositoryId } = getConfigurations();
   const getFolderByPathURL =
@@ -236,6 +262,7 @@ const updateServerRequest = async (url, formData, config) => {
 module.exports = {
   getRepositoryInfo,
   getFolderIdByPath,
+  getFolderIdByIDAsPath,
   createFolder,
   createAttachment,
   deleteAttachmentsOfFolder,

--- a/lib/persistence/index.js
+++ b/lib/persistence/index.js
@@ -64,6 +64,16 @@ async function getURLsToDeleteFromDraftAttachments(ID, draftAttachments) {
     .where(conditions);
 }
 
+async function getURLToDeleteFromDraftAttachments(id, draftAttachments) {
+  const conditions = {
+    ID: id,
+    HasActiveEntity: false
+  };
+  return await SELECT.from(draftAttachments)
+    .columns("url")
+    .where(conditions);
+}
+
 async function getExistingAttachments(attachmentIDs, attachments) {
   return await SELECT("filename", "url", "ID", "folderId")
     .from(attachments)
@@ -94,6 +104,7 @@ module.exports = {
   getDraftAttachmentsForUpID,
   getURLsToDeleteFromAttachments,
   getURLsToDeleteFromDraftAttachments,
+  getURLToDeleteFromDraftAttachments,
   getURLFromAttachments,
   getFolderIdForEntity,
   updateAttachmentInDraft,

--- a/lib/sdm.js
+++ b/lib/sdm.js
@@ -4,6 +4,7 @@ const cache = new NodeCache();
 const {
   getRepositoryInfo,
   getFolderIdByPath,
+  getFolderIdByIDAsPath,
   createFolder,
   createAttachment,
   deleteAttachmentsOfFolder,
@@ -26,6 +27,7 @@ const {
   getDraftAttachmentsForUpID,
   getURLsToDeleteFromAttachments,
   getURLsToDeleteFromDraftAttachments,
+  getURLToDeleteFromDraftAttachments,
   getURLFromAttachments,
   getFolderIdForEntity,
   updateAttachmentInDraft,
@@ -313,7 +315,7 @@ module.exports = class SDMAttachmentsService extends (
             this.creds,
             req.user.tokenInfo.getTokenValue()
           );
-          const folderId = await getFolderIdByPath(
+          const folderId = await getFolderIdByIDAsPath(
             req,
             this.creds,
             token,
@@ -340,7 +342,7 @@ module.exports = class SDMAttachmentsService extends (
           this.creds,
           req.user.tokenInfo.getTokenValue()
         );
-        const folderId = await getFolderIdByPath(
+        const folderId = await getFolderIdByIDAsPath(
           req,
           this.creds,
           token,
@@ -350,6 +352,17 @@ module.exports = class SDMAttachmentsService extends (
           req.parentId = folderId;
         }
       }
+    }
+  }
+
+  async attachURLsToDeleteFromAttachmentsDraft(req) {
+    let draftAttachments = cds.model.definitions[req.query.target.name];
+    if(draftAttachments)  {
+      const attachmentsToDeleteFromDraft = await getURLToDeleteFromDraftAttachments(req.data.ID, draftAttachments);
+      if (attachmentsToDeleteFromDraft?.length > 0) {
+        req.attachmentsToDelete = attachmentsToDeleteFromDraft;
+      }
+      await this.deleteAttachmentsWithKeys(req.attachmentsToDelete, req);
     }
   }
 
@@ -516,6 +529,7 @@ module.exports = class SDMAttachmentsService extends (
       entity.drafts,
       this.attachDraftDeletionData.bind(this)
     );
+    srv.before(["DELETE"], [target, target.drafts], this.attachURLsToDeleteFromAttachmentsDraft.bind(this));
     srv.before("READ", [target, target.drafts], this.setRepository.bind(this))
     srv.before("READ", [target, target.drafts], this.filterAttachments.bind(this))
     srv.before("SAVE", entity, this.renameHandler.bind(this));

--- a/test/lib/handler/index.test.js
+++ b/test/lib/handler/index.test.js
@@ -24,6 +24,7 @@ const {
   deleteAttachmentsOfFolder,
   readAttachment,
   getFolderIdByPath,
+  getFolderIdByIDAsPath,
   createFolder,
   deleteFolderWithAttachments,
   getAttachment,
@@ -156,7 +157,7 @@ describe("handlers", () => {
       mockedCredentials = { uri: "mocked_uri/" };
       mockedToken = "mocked_token";
       mockedAttachments = {
-        keys: { up_: { keys: [{ $generatedFieldName: "__idValue" }] } },
+        keys: { up_: { keys: [{ $generatedFieldName: "idValue" }] } },
       };
     });
 
@@ -234,6 +235,82 @@ describe("handlers", () => {
       expect(logSpy).toHaveBeenCalledWith("Some error occurred");
 
       // restore console.log
+      logSpy.mockRestore();
+    });
+  });
+
+  describe("Test for getFolderIdByIDAsPath", () => {
+    let mockedReq, mockedCredentials, mockedToken, mockedAttachments;
+  
+    beforeEach(() => {
+      jest.clearAllMocks();
+      mockedReq = { data: { '123': "testValue" } }; // Assuming the ID extracted from field is '123'
+      mockedCredentials = { uri: "mocked_uri/" };
+      mockedToken = "mocked_token";
+      mockedAttachments = {
+        keys: { up_: { keys: [{ $generatedFieldName: "field1__123" }] } },
+      };
+    });
+  
+    it("should return a folderId when axios request is successful", async () => {
+      const mockedResponse = {
+        data: { properties: { "cmis:objectId": { value: "folderId" } } },
+      };
+      axios.get.mockResolvedValue(mockedResponse);
+  
+      const result = await getFolderIdByIDAsPath(
+        mockedReq,
+        mockedCredentials,
+        mockedToken,
+        mockedAttachments
+      );
+  
+      // assertions
+      expect(result).toEqual("folderId");
+      expect(axios.get).toHaveBeenCalledWith(
+        "mocked_uri/browser/123/root/testValue?cmisselector=object",
+        { headers: { Authorization: "Bearer mocked_token" } }
+      );
+    });
+  
+    it("should return null when axios request fails", async () => {
+      axios.get.mockRejectedValue(new Error("Network error"));
+  
+      const result = await getFolderIdByIDAsPath(
+        mockedReq,
+        mockedCredentials,
+        mockedToken,
+        mockedAttachments
+      );
+  
+      // assertions
+      expect(result).toEqual(null);
+      expect(axios.get).toHaveBeenCalledWith(
+        "mocked_uri/browser/123/root/testValue?cmisselector=object",
+        { headers: { Authorization: "Bearer mocked_token" } }
+      );
+    });
+  
+    it("should log statusText and return null when axios.get throws an error with response.statusText", async () => {
+      // Create the mock objects
+      const errorResponse = { statusText: "Some error occurred" };
+      axios.get.mockRejectedValue({ response: errorResponse });
+  
+      // Spy on console.log
+      const logSpy = jest.spyOn(console, "log");
+  
+      // Call the function
+      const response = await getFolderIdByIDAsPath(
+        mockedReq,
+        mockedCredentials,
+        mockedToken,
+        mockedAttachments
+      );
+  
+      // Assert that the function returned null and printed the statusText
+      expect(response).toBeNull();
+      expect(logSpy).toHaveBeenCalledWith("Some error occurred");
+  
       logSpy.mockRestore();
     });
   });

--- a/test/lib/sdm.test.js
+++ b/test/lib/sdm.test.js
@@ -1026,13 +1026,8 @@ describe("SDMAttachmentsService", () => {
       // Mock implementation for getURLToDeleteFromDraftAttachments
       getURLToDeleteFromDraftAttachments.mockResolvedValue([{ url: 'http://example.com/attachment1', ID: '1' }]);
   
-      // Mock implementation for fetchAccessToken
-      fetchAccessToken.mockImplementation(async (creds, tokenValue) => {
-        return 'mockToken';
-      });
-  
       // Mock implementation for deleteAttachmentsOfFolder
-      deleteAttachmentsOfFolder.mockImplementation(async (creds, token, url) => {
+      deleteAttachmentsOfFolder.mockImplementation(async () => {
         return { status: 200 };
       });
     });
@@ -1075,8 +1070,6 @@ describe("SDMAttachmentsService", () => {
         user: { tokenInfo: { getTokenValue: jest.fn().mockReturnValue("tokenValue") } },
       };
       cds.model.definitions["DraftAttachments"] = {};
-  
-      const deleteAttachmentsSpy = jest.spyOn(service, 'deleteAttachmentsWithKeys');
       
       await service.attachURLsToDeleteFromAttachmentsDraft(req);
   

--- a/test/lib/sdm.test.js
+++ b/test/lib/sdm.test.js
@@ -14,6 +14,7 @@ const {
   getDraftAttachmentsForUpID,
   getURLsToDeleteFromAttachments,
   getURLsToDeleteFromDraftAttachments,
+  getURLToDeleteFromDraftAttachments,
   getURLFromAttachments,
   getFolderIdForEntity,
   updateAttachmentInDraft,
@@ -24,6 +25,7 @@ const {
   createAttachment,
   readAttachment,
   getFolderIdByPath,
+  getFolderIdByIDAsPath,
   createFolder,
   deleteFolderWithAttachments,
   getAttachment,
@@ -50,6 +52,7 @@ jest.mock("../../lib/persistence", () => ({
   getDuplicateAttachments: jest.fn(),
   getURLsToDeleteFromAttachments: jest.fn(),
   getURLsToDeleteFromDraftAttachments: jest.fn(),
+  getURLToDeleteFromDraftAttachments: jest.fn(),
   getURLFromAttachments: jest.fn(),
   getFolderIdForEntity: jest.fn(),
   updateAttachmentInDraft: jest.fn(),
@@ -70,6 +73,7 @@ jest.mock("../../lib/handler", () => ({
   createAttachment: jest.fn(),
   readAttachment: jest.fn(),
   getFolderIdByPath: jest.fn(),
+  getFolderIdByIDAsPath: jest.fn(),
   createFolder: jest.fn(),
   deleteFolderWithAttachments: jest.fn(),
   getAttachment: jest.fn(),
@@ -916,10 +920,10 @@ describe("SDMAttachmentsService", () => {
       };
 
       getURLsToDeleteFromAttachments.mockResolvedValueOnce(["url"]);
-      getFolderIdByPath.mockResolvedValueOnce("folder");
+      getFolderIdByIDAsPath.mockResolvedValueOnce("folder");
       await service.attachDeletionData(mockedReq);
       expect(mockedReq.parentId).toEqual("folder");
-      expect(getFolderIdByPath).toHaveBeenCalledTimes(1);
+      expect(getFolderIdByIDAsPath).toHaveBeenCalledTimes(1);
     });
 
     it("attachDeletionData() should not set req.parentId if event is DELETE and getFolderIdForEntity() returns empty array", async () => {
@@ -945,10 +949,10 @@ describe("SDMAttachmentsService", () => {
       };
 
       getURLsToDeleteFromAttachments.mockResolvedValueOnce(["url"]);
-      getFolderIdByPath.mockResolvedValueOnce(null);
+      getFolderIdByIDAsPath.mockResolvedValueOnce(null);
       await service.attachDeletionData(mockedReq);
       expect(mockedReq.parentId).toBeUndefined();
-      expect(getFolderIdByPath).toHaveBeenCalledTimes(1);
+      expect(getFolderIdByIDAsPath).toHaveBeenCalledTimes(1);
     });
 
     it("attachDeletionData() should not call getFolderIdForEntity() if event is not DELETE", async () => {
@@ -1010,14 +1014,87 @@ describe("SDMAttachmentsService", () => {
     });
   });
 
+  describe('attachURLsToDeleteFromAttachmentsDraft', () => {
+  
+    let service;
+    
+    beforeEach(() => {
+      jest.clearAllMocks();
+      cds = require("@sap/cds/lib");
+      service = new SDMAttachmentsService();
+      
+      // Mock implementation for getURLToDeleteFromDraftAttachments
+      getURLToDeleteFromDraftAttachments.mockResolvedValue([{ url: 'http://example.com/attachment1', ID: '1' }]);
+  
+      // Mock implementation for fetchAccessToken
+      fetchAccessToken.mockImplementation(async (creds, tokenValue) => {
+        return 'mockToken';
+      });
+  
+      // Mock implementation for deleteAttachmentsOfFolder
+      deleteAttachmentsOfFolder.mockImplementation(async (creds, token, url) => {
+        return { status: 200 };
+      });
+    });
+
+    afterEach(() => {
+      jest.clearAllMocks();
+    });
+    
+    it('should attach URLs to delete and call deleteAttachmentsWithKeys with correct data', async () => {
+      const req = {
+        query: { target: { name: 'DraftAttachments' } },
+        data: { ID: 'some-id' },
+        user: { tokenInfo: { getTokenValue: jest.fn().mockReturnValue("tokenValue") } },
+      };
+      cds.model.definitions["DraftAttachments"] = {};
+  
+      // Define a mock function on the service instance to observe it being called
+      const deleteAttachmentsSpy = jest.spyOn(service, 'deleteAttachmentsWithKeys');
+      
+      // Call the method
+      await service.attachURLsToDeleteFromAttachmentsDraft(req);
+      
+      expect(req.attachmentsToDelete).toEqual([{ url: 'http://example.com/attachment1', ID: '1' }]);
+      
+      // Validate deleteAttachmentsWithKeys has been called
+      expect(deleteAttachmentsSpy).toHaveBeenCalled();
+      
+      // Validate deleteAttachmentsWithKeys is called with the correct arguments
+      expect(deleteAttachmentsSpy).toHaveBeenCalledWith(req.attachmentsToDelete, req);
+    });
+    
+    it('should not call deleteAttachmentsWithKeys if there are no attachments to delete', async () => {
+      getURLToDeleteFromDraftAttachments.mockImplementationOnce(async () => {
+        return [];
+      });
+  
+      const req = {
+        query: { target: { name: 'DraftAttachments' } },
+        data: { ID: 'some-other-id' },
+        user: { tokenInfo: { getTokenValue: jest.fn().mockReturnValue("tokenValue") } },
+      };
+      cds.model.definitions["DraftAttachments"] = {};
+  
+      const deleteAttachmentsSpy = jest.spyOn(service, 'deleteAttachmentsWithKeys');
+      
+      await service.attachURLsToDeleteFromAttachmentsDraft(req);
+  
+      expect(req.attachmentsToDelete).toBeUndefined();
+    });
+  });
+
   describe("deleteAttachmentsWithKeys", () => {
     let service;
     beforeEach(() => {
       jest.clearAllMocks();
       service = new SDMAttachmentsService();
     });
+    afterEach(() => {
+      jest.clearAllMocks();
+    });
     it("should delete attachments if req.attachmentsToDelete has records to delete", async () => {
-      const records = []; // Add required records data
+      const records = [];
       const req = {
         query: { target: { name: "testTarget" } },
         attachmentsToDelete: [
@@ -1034,7 +1111,7 @@ describe("SDMAttachmentsService", () => {
 
       const expectedErrorResponse = "test_error_response";
 
-      cds.model.definitions["testTarget.attachments"] = {}; // Add relevant attachment definition
+      cds.model.definitions["testTarget.attachments"] = {};
       fetchAccessToken.mockResolvedValueOnce("test_token");
       deleteAttachmentsOfFolder.mockResolvedValueOnce({});
       service.handleRequest = jest
@@ -1825,7 +1902,7 @@ describe("SDMAttachmentsService", () => {
       });
   
       fetchAccessToken.mockResolvedValueOnce("mocked_token");
-      getFolderIdByPath.mockResolvedValueOnce("mock_folder_id");
+      getFolderIdByIDAsPath.mockResolvedValueOnce("mock_folder_id");
   
       await service.attachDraftDeletionData(mockReq);
   


### PR DESCRIPTION
In this PR we are fixing issue with deletion of attachments from SDM repositories when entity is in draft state and has not been saved once. Updated the changeLog for this fix as well.

Ran Integration Tests by deploying this branch and tests ran successfully.
<img width="732" alt="Screenshot 2025-04-21 at 11 57 11 AM" src="https://github.com/user-attachments/assets/f171152f-cc65-4bdc-8943-689f9fdfabb2" />

Also, Tested below features:
Create Entity, Added few attachments and deleted 2 attachments before saving the entity. => Attachment got deleted from SDM as soon as I deleted the attachment.
Create Entity, Added few attachments and discarded draft before saving the entity. => Folder and all the attachments are deleted.
Create Entity, Added few attachments, save the entity, Edit entity, Added 2 new attachments, Deleted the newly added attachment before saving the entity.  => Attachment got deleted from SDM as soon as I deleted the attachment.
Create Entity, Added few attachments, save the entity, Edit entity, Added 2 new attachments, Deleted the attachment that were added before saving the antity and saved the entity   => Attachment got deleted from SDM only after saving the entity.



