### PR TITLE
Fix bug when Entity's primary key is not ID

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 - Handling of special characters in attachments name during upload and rename of attachments.
 
 ### Fixed
+- Error to allow any name in the primary key for the entity.
 - Issue with deleting attachments from SDM when the entity has not been saved once.
 - Error message in case of rename when attachment is deleted from backend SDM repository.
 

--- a/lib/persistence/index.js
+++ b/lib/persistence/index.js
@@ -40,11 +40,9 @@ async function getFolderIdForEntity(attachments, req, repositoryId) {
 }
 
 async function updateAttachmentInDraft(req, data) {
-  const up_ = req.target.keys.up_.keys[0].$generatedFieldName;
-  const idValue = up_.split("__")[1];
   return await UPDATE(req.target)
     .set({ folderId: data.folderId, url: data.url, status: "Clean" })
-    .where({ [idValue]: req.data[idValue] });
+    .where({ ["ID"]: req.data["ID"] });
 }
 
 async function getURLsToDeleteFromAttachments(deletedAttachments, attachments) {


### PR DESCRIPTION
## Describe your changes
Once the attachment is created successfully in SDM folderId & objectId are updated in attachments_drafts table such that same can be updated in attachments table as well on Save of the entity. To update the attachments_drafts table Primary key of the attachment is needed to add it in where clause.
Till now we were using `const up_ = attachments.keys.up_.keys[0].$generatedFieldName;` which is up__ID and then
splitting based on __ as `const idValue = up_.split("__")[1];` resulting in ID. Finally executing the update query by passing this key ID in where clause. Now consider a scenario, when entities primary key is not ID, let's suppose it is ProjectCode. In this case `const up_ = attachments.keys.up_.keys[0].$generatedFieldName;` will give up__ProjectCode and after splitting we will end with ProjectCode as the key. And since, attachments_draft table won't have any column with name ProjectCode. We were getting error. To fix this hard-coded this field as "ID" as in Aspect Attachments primary key is cuid which will always generate the key as ID.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist before requesting a review

- [x] I have tested the functionality on my cloud environment.
- [N/A] I have  provided sufficient automated/ unit tests for the code.
- [x] I have increased or maintained the test coverage.
- [x] I have ran integration tests on my cloud environment.
- [ ] I have validated blackduck portal for any vulnerability after my commit.

## Upload Screenshots/lists of the scenarios tested
- [x] I have Uploaded Screenshots or added lists of the scenarios tested in description
Ran Integration test by deploying my changes on my space.
Tested upload attachments in application in which the issue was reported.

