### PR TITLE
Custom property support

### DIFF
--- a/lib/handler/index.js
+++ b/lib/handler/index.js
@@ -242,7 +242,7 @@ async function updateAttachment(
   try {
     secondaryTypes = await getSecondaryTypes(req, repositoryId, token, credentials);
   } catch (error) {
-    console.error("Error fetching secondary types:", error);
+    console.log("Error fetching secondary types:", error);
     return 500;
   }
 
@@ -264,8 +264,8 @@ async function updateAttachment(
   );
   console.log("Keys to remove:", keysToRemove);
 
-  for (const [key, value] of Object.entries(secondaryPropertiesWithInvalidDefinitions)) {
-    if (updatedSecondaryProperties.hasOwnProperty(value)) {
+  for (const [, value] of Object.entries(secondaryPropertiesWithInvalidDefinitions)) {
+    if (Object.hasOwn(updatedSecondaryProperties, value)) {
       keysToRemove.push(value);
     }
   }
@@ -365,7 +365,7 @@ async function getValidSecondaryProperties(req, secondaryTypes, sdmCredentials, 
   if (!validSecondaryProperties) {
     validSecondaryProperties = [];
 
-    for (let i = 0; i < secondaryTypes.length; i++) {
+    for (let i = secondaryTypes.length - 1; i >= 0; i--) {
       const typeId = secondaryTypes[i];
       const sdmUrl = `${sdmCredentials.uri}browser/${repositoryId}?cmisselector=typeDefinition&typeID=${typeId}`;
 
@@ -383,8 +383,7 @@ async function getValidSecondaryProperties(req, secondaryTypes, sdmCredentials, 
 
         // Remove invalid types
         if (!isValid) {
-          secondaryTypes.splice(i, 1);
-          i--; // Adjust index after removal
+          secondaryTypes.splice(i, 1); // No need to adjust the index
         }
       } catch (error) {
         const reasonPhrase = error.response ? error.response.statusText : 'Unknown error';

--- a/lib/handler/index.js
+++ b/lib/handler/index.js
@@ -1,7 +1,9 @@
-const { getConfigurations } = require("../util");
+const { getConfigurations, extractSecondaryTypeIds, checkMCM, prepareSecondaryProperties } = require("../util");
 const axios = require("axios").default;
 const FormData = require("form-data");
-const { errorMessage } = require("../util/messageConsts");
+const { errorMessage, updateAttachmentError, unsupportedProperties } = require("../util/messageConsts");
+const NodeCache = require("node-cache");
+const cache = new NodeCache({ stdTTL: 3600 });
 
 async function readAttachment(Key, token, credentials) {
   const document = await readDocument(Key, token, credentials.uri);
@@ -222,31 +224,195 @@ async function getAttachment(uri, token, objectId) {
   }
 }
 
-async function renameAttachment(
-  modifiedAttachment,
+/**
+ * Updates an attachment in the SDM repository.
+ * @param {Object} attachment - The attachment object containing metadata.
+ * @param {Object} credentials - The SDM credentials object.
+ * @param {string} token - The JWT token for authentication.
+ * @param {Object} updatedSecondaryProperties - Map of secondary properties to update.
+ * @param {Object} secondaryPropertiesWithInvalidDefinitions - Map of invalid secondary properties.
+ * @returns {number} - The HTTP status code of the update request.
+ * @throws {Error} - Throws an error if the update fails or unsupported properties are found.
+ */
+async function updateAttachment(
+  req,
+  attachment,
   credentials,
   token,
-) {
+  updatedSecondaryProperties,
+  secondaryPropertiesWithInvalidDefinitions
+  ) {
   const { repositoryId } = getConfigurations();
-  const documentRenameURL =
-    credentials.uri + "browser/" + repositoryId + "/root";
+  const objectId = attachment.url;
+
+  // Fetch secondary types
+  let secondaryTypes;
+  try {
+    secondaryTypes = await getSecondaryTypes(req, repositoryId, token, credentials);
+  } catch (error) {
+    return 500;
+  }
+
+  // Fetch valid secondary properties
+  const validSecondaryProperties = await getValidSecondaryProperties(
+    req,
+    secondaryTypes,
+    credentials,
+    repositoryId,
+    token
+  );
+
+  cache.set(repositoryId, secondaryTypes);
+  cache.set(`validSecondaryProperties_${repositoryId}`, validSecondaryProperties);
+
+  // Adding the properties which are unsupported to a list so that exeception can be thrown
+  const keysToRemove = Object.keys(updatedSecondaryProperties).filter(
+    (key) => key !== "cmis:name" && !validSecondaryProperties.includes(key)
+  );
+  console.log("Keys to remove:", keysToRemove);
+
+  for (const [key, value] of Object.entries(secondaryPropertiesWithInvalidDefinitions)) {
+    if (updatedSecondaryProperties.hasOwnProperty(value)) {
+      keysToRemove.push(value);
+    }
+  }
+
+  /** 
+   * Some invalid/unsupported properties were present and were updated.
+   * So processing is stopped (Request is not sent to SDM) and exception is thrown
+  */
+  if (keysToRemove.length > 0) {
+    const errorMessage = keysToRemove.join(", ");
+    // console.error("Unsupported properties found:", errorMessage);
+    throw new Error(`${unsupportedProperties} ${errorMessage}`);
+  }
+
+  // Prepare the request URL
+  const updateURL = `${credentials.uri}browser/${repositoryId}/root?objectId=${objectId}`;
+
+  // Prepare the request body
   const formData = new FormData();
   formData.append("cmisaction", "update");
-  formData.append("propertyId[0]", "cmis:name");
-  formData.append("propertyValue[0]", modifiedAttachment.name);
-  formData.append("objectId", modifiedAttachment.url);
-  
+  formData.append("propertyId[0]", "cmis:secondaryObjectTypeIds");
+
+  // Add secondary types to the request body
+  secondaryTypes.forEach((type, index) => {
+    formData.append(`propertyValue[0][${index}]`, type);
+  });
+
+  // Add secondary properties to the request body
+  prepareSecondaryProperties(formData, updatedSecondaryProperties);
+
+  // Add headers
   let headers = formData.getHeaders();
   headers["Authorization"] = "Bearer " + token;
+
+  // Send the request
   const config = {
     headers: headers,
   };
-  const response = await updateServerRequest(
-    documentRenameURL,
-    formData,
-    config
-  );
-  return response;
+
+  try {
+    const response = await updateServerRequest(updateURL, formData, config);
+    if (response?.response?.status === 400) {
+      const jsonResponse = await response.response.json();
+      const message = jsonResponse.message;
+      throw new Error(message);
+    }
+    return response.status; // Return the HTTP status code
+  } catch (error) {
+    // if (error.response && error.response.status === 400) {
+    //   const jsonResponse = await error.response.json();
+    //   const message = jsonResponse.message;
+    //   throw new Error(message);
+    // }
+    throw new Error(updateAttachmentError, error);
+  }
+}
+
+/**
+ * Fetches secondary types from the SDM repository with caching.
+ */
+async function getSecondaryTypes(req, repositoryId, token, credentials) {
+  const cacheKey = repositoryId;
+  let secondaryTypes = cache.get(cacheKey);
+
+  if (!secondaryTypes) {
+    const sdmUrl = `${credentials.uri}browser/${repositoryId}?cmisselector=typeDescendants`;
+
+    // Prepare headers
+    const headers = {
+      Authorization: `Bearer ${token}`,
+    };
+
+    try {
+      // Send the GET request using axios
+      const response = await axios.get(sdmUrl, { headers });
+
+      const jsonArray = response.data;
+      const result = [];
+
+      // Extract secondary types
+      let secondaryTypesJSON = [];
+      for (const jsonObject of jsonArray) {
+        if (jsonObject.type.id === "cmis:secondary") {
+          secondaryTypesJSON = jsonObject.children || [];
+          break; // Exit the loop once the correct type is found
+        }
+      }
+
+      // Extract secondary type IDs
+      extractSecondaryTypeIds(secondaryTypesJSON, result);
+      return result;
+    } catch (error) {
+      // const reasonPhrase = error.response ? error.response.statusText : 'Unknown error';
+      // const statusCode = error.response ? error.response.status : 'Unknown status code';
+      throw new Error('Could not update the attachment', error);
+    }
+  }
+
+  return secondaryTypes;
+}
+
+/**
+ * Fetches valid secondary properties from the SDM repository with caching.
+ */
+async function getValidSecondaryProperties(req, secondaryTypes, sdmCredentials, repositoryId, jwtToken) {
+  const cacheKey = `validSecondaryProperties_${repositoryId}`;
+  let validSecondaryProperties = cache.get(cacheKey);
+
+  if (!validSecondaryProperties) {
+    validSecondaryProperties = [];
+
+    for (let i = 0; i < secondaryTypes.length; i++) {
+      const typeId = secondaryTypes[i];
+      const sdmUrl = `${sdmCredentials.uri}browser/${repositoryId}?cmisselector=typeDefinition&typeID=${typeId}`;
+
+      // Prepare headers
+      const headers = {
+        Authorization: `Bearer ${jwtToken}`,
+      };
+
+      try {
+        // Send the GET request using axios
+        const response = await axios.get(sdmUrl, { headers });
+
+        const responseBody = JSON.stringify(response.data);
+        const isValid = checkMCM(responseBody, validSecondaryProperties);
+
+        // Remove invalid types
+        if (!isValid) {
+          secondaryTypes.splice(i, 1);
+          i--; // Adjust index after removal
+        }
+      } catch (error) {
+        const reasonPhrase = error.response ? error.response.statusText : 'Unknown error';
+        req.reject(updateAttachmentError + ": " + reasonPhrase);
+      }
+    }
+  }
+
+  return validSecondaryProperties;
 }
 
 const updateServerRequest = async (url, formData, config) => {
@@ -269,5 +435,5 @@ module.exports = {
   deleteFolderWithAttachments,
   getAttachment,
   readAttachment,
-  renameAttachment
+  updateAttachment
 };

--- a/lib/handler/index.js
+++ b/lib/handler/index.js
@@ -224,16 +224,8 @@ async function getAttachment(uri, token, objectId) {
   }
 }
 
-/**
- * Updates an attachment in the SDM repository.
- * @param {Object} attachment - The attachment object containing metadata.
- * @param {Object} credentials - The SDM credentials object.
- * @param {string} token - The JWT token for authentication.
- * @param {Object} updatedSecondaryProperties - Map of secondary properties to update.
- * @param {Object} secondaryPropertiesWithInvalidDefinitions - Map of invalid secondary properties.
- * @returns {number} - The HTTP status code of the update request.
- * @throws {Error} - Throws an error if the update fails or unsupported properties are found.
- */
+
+//Updates an attachment in the SDM repository.
 async function updateAttachment(
   req,
   attachment,
@@ -250,6 +242,7 @@ async function updateAttachment(
   try {
     secondaryTypes = await getSecondaryTypes(req, repositoryId, token, credentials);
   } catch (error) {
+    console.error("Error fetching secondary types:", error);
     return 500;
   }
 
@@ -283,7 +276,6 @@ async function updateAttachment(
   */
   if (keysToRemove.length > 0) {
     const errorMessage = keysToRemove.join(", ");
-    // console.error("Unsupported properties found:", errorMessage);
     throw new Error(`${unsupportedProperties} ${errorMessage}`);
   }
 
@@ -321,18 +313,11 @@ async function updateAttachment(
     }
     return response.status; // Return the HTTP status code
   } catch (error) {
-    // if (error.response && error.response.status === 400) {
-    //   const jsonResponse = await error.response.json();
-    //   const message = jsonResponse.message;
-    //   throw new Error(message);
-    // }
     throw new Error(updateAttachmentError, error);
   }
 }
 
-/**
- * Fetches secondary types from the SDM repository with caching.
- */
+//Fetches secondary types from the SDM repository with caching.
 async function getSecondaryTypes(req, repositoryId, token, credentials) {
   const cacheKey = repositoryId;
   let secondaryTypes = cache.get(cacheKey);
@@ -365,8 +350,6 @@ async function getSecondaryTypes(req, repositoryId, token, credentials) {
       extractSecondaryTypeIds(secondaryTypesJSON, result);
       return result;
     } catch (error) {
-      // const reasonPhrase = error.response ? error.response.statusText : 'Unknown error';
-      // const statusCode = error.response ? error.response.status : 'Unknown status code';
       throw new Error('Could not update the attachment', error);
     }
   }
@@ -374,9 +357,7 @@ async function getSecondaryTypes(req, repositoryId, token, credentials) {
   return secondaryTypes;
 }
 
-/**
- * Fetches valid secondary properties from the SDM repository with caching.
- */
+//Fetches valid secondary properties from the SDM repository with caching.
 async function getValidSecondaryProperties(req, secondaryTypes, sdmCredentials, repositoryId, jwtToken) {
   const cacheKey = `validSecondaryProperties_${repositoryId}`;
   let validSecondaryProperties = cache.get(cacheKey);

--- a/lib/handler/index.js
+++ b/lib/handler/index.js
@@ -240,7 +240,7 @@ async function updateAttachment(
   // Fetch secondary types
   let secondaryTypes;
   try {
-    secondaryTypes = await getSecondaryTypes(req, repositoryId, token, credentials);
+    secondaryTypes = await getSecondaryTypes(repositoryId, token, credentials);
   } catch (error) {
     console.log("Error fetching secondary types:", error);
     return 500;
@@ -262,7 +262,6 @@ async function updateAttachment(
   const keysToRemove = Object.keys(updatedSecondaryProperties).filter(
     (key) => key !== "cmis:name" && !validSecondaryProperties.includes(key)
   );
-  console.log("Keys to remove:", keysToRemove);
 
   for (const [, value] of Object.entries(secondaryPropertiesWithInvalidDefinitions)) {
     if (Object.hasOwn(updatedSecondaryProperties, value)) {
@@ -275,7 +274,7 @@ async function updateAttachment(
    * So processing is stopped (Request is not sent to SDM) and exception is thrown
   */
   if (keysToRemove.length > 0) {
-    const errorMessage = keysToRemove.join(", ");
+    const errorMessage = keysToRemove.join(",");
     throw new Error(`${unsupportedProperties} ${errorMessage}`);
   }
 
@@ -318,7 +317,7 @@ async function updateAttachment(
 }
 
 //Fetches secondary types from the SDM repository with caching.
-async function getSecondaryTypes(req, repositoryId, token, credentials) {
+async function getSecondaryTypes(repositoryId, token, credentials) {
   const cacheKey = repositoryId;
   let secondaryTypes = cache.get(cacheKey);
 

--- a/lib/persistence/index.js
+++ b/lib/persistence/index.js
@@ -104,12 +104,6 @@ async function getURLToDeleteFromDraftAttachments(id, draftAttachments) {
     .where(conditions);
 }
 
-// async function getExistingAttachments(attachmentIDs, attachments) {
-//   return await SELECT("filename", "url", "ID", "folderId")
-//     .from(attachments)
-//     .where({ ID: { in: [...attachmentIDs] }});
-// }
-
 async function setRepositoryId(attachments, repositoryId) {
   if(attachments) {
     let nullAttachments = await SELECT()

--- a/lib/persistence/index.js
+++ b/lib/persistence/index.js
@@ -12,7 +12,7 @@ async function getDraftAttachments(attachments, req, repositoryId) {
     [up_]: req.data[idValue],
     repositoryId: repositoryId
   };
-  return await SELECT("filename", "mimeType", "content", "url", "ID", "HasActiveEntity")
+  return await SELECT("*")
     .from(attachments.drafts)
     .where(conditions)
 }
@@ -26,6 +26,38 @@ async function getDraftAttachmentsForUpID(attachments, req, repositoryId) {
   return await SELECT("filename", "mimeType", "content", "url", "ID", "HasActiveEntity")
     .from(attachments)
     .where(conditions)
+}
+
+async function getFileNameForAttachmentID(attachmentsEntity, attachmentID) {
+  const files = await SELECT.from(attachmentsEntity)
+    .columns("filename")
+    .where({ ID: attachmentID });
+
+  // Ensure the result is not empty and return the filename
+  if (files.length > 0 && files[0].filename) {
+    return files[0].filename.toString();
+  }
+
+  // Return null if no file is found
+  return null;
+}
+
+async function getPropertiesForID(attachmentsEntity, id, secondaryTypeProperties) {
+  // Build the query
+  const propertyKeys = Object.keys(secondaryTypeProperties);
+  const result = await SELECT.from(attachmentsEntity)
+    .columns(...propertyKeys)
+    .where({ ID: id });
+
+  const propertyValueMap = {};
+
+  // Iterate through the properties map and populate propertyValueMap
+  for (const [property, mapKey] of secondaryTypeProperties.entries()) {
+    const value = result.length > 0 ? result[0][property] : null;
+    propertyValueMap[mapKey] = value !== null ? value : null;
+  }
+
+  return propertyValueMap;
 }
 
 async function getFolderIdForEntity(attachments, req, repositoryId) {
@@ -72,11 +104,11 @@ async function getURLToDeleteFromDraftAttachments(id, draftAttachments) {
     .where(conditions);
 }
 
-async function getExistingAttachments(attachmentIDs, attachments) {
-  return await SELECT("filename", "url", "ID", "folderId")
-    .from(attachments)
-    .where({ ID: { in: [...attachmentIDs] }});
-}
+// async function getExistingAttachments(attachmentIDs, attachments) {
+//   return await SELECT("filename", "url", "ID", "folderId")
+//     .from(attachments)
+//     .where({ ID: { in: [...attachmentIDs] }});
+// }
 
 async function setRepositoryId(attachments, repositoryId) {
   if(attachments) {
@@ -100,12 +132,13 @@ async function setRepositoryId(attachments, repositoryId) {
 module.exports = {
   getDraftAttachments,
   getDraftAttachmentsForUpID,
+  getFileNameForAttachmentID,
+  getPropertiesForID,
   getURLsToDeleteFromAttachments,
   getURLsToDeleteFromDraftAttachments,
   getURLToDeleteFromDraftAttachments,
   getURLFromAttachments,
   getFolderIdForEntity,
   updateAttachmentInDraft,
-  getExistingAttachments,
   setRepositoryId
 };

--- a/lib/sdm.js
+++ b/lib/sdm.js
@@ -142,130 +142,81 @@ module.exports = class SDMAttachmentsService extends (
       } 
     }
   }
-
-  async updateNonDraftAttachments(req, token, attachment, attachmentsEntity, secondaryPropertiesWithInvalidDefinitions, secondaryTypeProperties) {
-    let failedReq = [];
-    const fileNameInDB = await getFileNameForAttachmentID(attachmentsEntity, attachment.ID);
-    // Fetching the values of the properties from the DB
-    const propertiesInDB = await getPropertiesForID(attachmentsEntity, attachment.ID, secondaryTypeProperties);
-    const updatedSecondaryProperties = getUpdatedSecondaryProperties(attachment, secondaryTypeProperties, propertiesInDB);
-    const filenameInRequest = attachment.filename;
-
-    if (isRestrictedCharactersInName(filenameInRequest)) {
-      failedReq.push({typeOfError: 'restricted characters', name: filenameInRequest});
-      this.replacePropertiesInAttachment(
-        req, attachment.ID, fileNameInDB, propertiesInDB, secondaryTypeProperties);
-      return failedReq;
-    }
-    if (fileNameInDB == null) {
-      if (filenameInRequest != null) {
-        updatedSecondaryProperties["cmis:name"] = filenameInRequest;
-      } else {
-        throw new Error("Filename cannot be empty");
-      }
-    } else {
-      if (filenameInRequest == null) {
-        throw new Error("Filename cannot be empty");
-      } else if (fileNameInDB !== filenameInRequest) {
-        updatedSecondaryProperties["cmis:name"] = filenameInRequest;
-      }
-    }
-    if (Object.keys(updatedSecondaryProperties).length > 0) {
-      try {
-        const responseCode = await updateAttachment(req, attachment, this.creds, token, updatedSecondaryProperties, secondaryPropertiesWithInvalidDefinitions);
-    
-        switch (responseCode) {
-          case 403:
-            // SDM Roles for user are missing
-            failedReq.push({typeOfError: 'no sdm roles', name: filenameInRequest});
-            this.replacePropertiesInAttachment(req, attachment.ID, fileNameInDB, propertiesInDB, secondaryTypeProperties);
-            break;
-    
-          case 409:
-            failedReq.push({typeOfError: 'duplicate', name: filenameInRequest});
-            this.replacePropertiesInAttachment(req, attachment.ID, fileNameInDB, propertiesInDB, secondaryTypeProperties);
-            break;
-    
-          case 404:
-            failedReq.push({typeOfError:'not found', name: filenameInRequest});
-            this.replacePropertiesInAttachment(req, attachment.ID, fileNameInDB, propertiesInDB, secondaryTypeProperties);
-            break;
-    
-          case 200:
-          case 201:
-            // Success cases, do nothing
-            break;
-    
-          default:
-            throw new Error(sdmRolesErrorMessage);
-        }
-      } catch (e) {
-        // This exception is thrown when there are unsupported properties in the request
-        if (e.message.startsWith(unsupportedProperties)) {
-          const unsupportedDetails = e.message.substring(unsupportedProperties.length).trim();
-          failedReq.push({ typeOfError: 'unsupported properties', details: unsupportedDetails });
-          this.replacePropertiesInAttachment(req, attachment.ID, fileNameInDB, propertiesInDB, secondaryTypeProperties);
-        } else {
-          failedReq.push({ typeOfError: 'bad request', name: filenameInRequest, message: e.message });
-          this.replacePropertiesInAttachment(req, attachment.ID, fileNameInDB, propertiesInDB, secondaryTypeProperties);
-        }
-      }
-    }
-
-    return failedReq;
-  }
-
+  
   async updateDraftAttachments(req, token, attachment, attachmentsEntity, secondaryPropertiesWithInvalidDefinitions, secondaryTypeProperties) {
-    let failedReq = [];
-    // Fetching the values of the properties from the DB
     const attachmentData = await this.getAttachementDataInSDM(this.creds.uri, token, attachment.url);
     const filenameInSDM = attachmentData.filename;
+    return this._updateAttachments(
+      req,
+      token,
+      attachment,
+      attachmentsEntity,
+      secondaryPropertiesWithInvalidDefinitions,
+      secondaryTypeProperties,
+      filenameInSDM
+    );
+  }
+
+  async updateNonDraftAttachments(req, token, attachment, attachmentsEntity, secondaryPropertiesWithInvalidDefinitions, secondaryTypeProperties) {
+    const fileNameInDB = await getFileNameForAttachmentID(attachmentsEntity, attachment.ID);
+    return this._updateAttachments(
+      req,
+      token,
+      attachment,
+      attachmentsEntity,
+      secondaryPropertiesWithInvalidDefinitions,
+      secondaryTypeProperties,
+      fileNameInDB
+    );
+  }
+  
+  async _updateAttachments(req, token, attachment, attachmentsEntity, secondaryPropertiesWithInvalidDefinitions, secondaryTypeProperties, filenameInSDM) {
+    let failedReq = [];
     const propertiesInDB = await getPropertiesForID(attachmentsEntity, attachment.ID, secondaryTypeProperties);
     const updatedSecondaryProperties = getUpdatedSecondaryProperties(attachment, secondaryTypeProperties, propertiesInDB);
     const filenameInRequest = attachment.filename;
-
+  
     if (isRestrictedCharactersInName(filenameInRequest)) {
-      failedReq.push({typeOfError:'restricted characters', filenameInRequest});
-      this.replacePropertiesInAttachment(
-        req, attachment.ID, filenameInSDM, propertiesInDB, secondaryTypeProperties);
+      failedReq.push({ typeOfError: 'restricted characters', name: filenameInRequest });
+      this.replacePropertiesInAttachment(req, attachment.ID, filenameInSDM, propertiesInDB, secondaryTypeProperties);
       return failedReq;
     }
+  
     if (filenameInRequest == null) {
       req.reject(400, "Filename cannot be empty");
     } else if (filenameInSDM !== filenameInRequest) {
       updatedSecondaryProperties["cmis:name"] = filenameInRequest;
     }
+  
     if (Object.keys(updatedSecondaryProperties).length > 0) {
       try {
         const responseCode = await updateAttachment(req, attachment, this.creds, token, updatedSecondaryProperties, secondaryPropertiesWithInvalidDefinitions);
-
+  
         switch (responseCode) {
           case 403:
-            // SDM Roles for user are missing
-            failedReq.push({typeOfError: 'no sdm roles', name: filenameInRequest});
+            failedReq.push({ typeOfError: 'no sdm roles', name: filenameInRequest });
             this.replacePropertiesInAttachment(req, attachment.ID, filenameInSDM, propertiesInDB, secondaryTypeProperties);
             break;
-    
+  
           case 409:
-            failedReq.push({typeOfError: 'duplicate', name: filenameInRequest});
+            failedReq.push({ typeOfError: 'duplicate', name: filenameInRequest });
             this.replacePropertiesInAttachment(req, attachment.ID, filenameInSDM, propertiesInDB, secondaryTypeProperties);
             break;
-    
+  
           case 404:
-            failedReq.push({typeOfError: 'not found', name: filenameInRequest});
+            failedReq.push({ typeOfError: 'not found', name: filenameInRequest });
             this.replacePropertiesInAttachment(req, attachment.ID, filenameInSDM, propertiesInDB, secondaryTypeProperties);
             break;
-    
+  
           case 200:
           case 201:
             // Success cases, do nothing
             break;
-    
+  
           default:
             throw new Error(sdmRolesErrorMessage);
         }
       } catch (e) {
-        // This exception is thrown when there are unsupported properties in the request
         if (e.message.startsWith(unsupportedProperties)) {
           const unsupportedDetails = e.message.substring(unsupportedProperties.length).trim();
           failedReq.push({ typeOfError: 'unsupported properties', details: unsupportedDetails });
@@ -276,7 +227,7 @@ module.exports = class SDMAttachmentsService extends (
         }
       }
     }
-
+  
     return failedReq;
   }
 
@@ -287,9 +238,7 @@ module.exports = class SDMAttachmentsService extends (
     }
 
     if (propertiesInDB) {
-      let i = 0;
       for (const [dbKey, dbValue] of Object.entries(propertiesInDB)) {
-        // Use Map.prototype.entries() to find the key in secondaryTypeProperties
         const secondaryKey = [...secondaryTypeProperties.entries()]
           .find(([_, value]) => value === dbKey)?.[0];
   

--- a/lib/sdm.js
+++ b/lib/sdm.js
@@ -240,7 +240,7 @@ module.exports = class SDMAttachmentsService extends (
     if (propertiesInDB) {
       for (const [dbKey, dbValue] of Object.entries(propertiesInDB)) {
         const secondaryKey = [...secondaryTypeProperties.entries()]
-          .find(([_, value]) => value === dbKey)?.[0];
+          .find(([, value]) => value === dbKey)?.[0];
   
         if (secondaryKey) {
           attachment[secondaryKey] = dbValue;

--- a/lib/sdm.js
+++ b/lib/sdm.js
@@ -11,20 +11,25 @@ const {
   deleteFolderWithAttachments,
   getAttachment,
   readAttachment,
-  renameAttachment
+  updateAttachment
 } = require("./handler/index");
 const {
   fetchAccessToken,
-  checkAttachmentsToRename,
   isRepositoryVersioned,
   getConfigurations,
   getClientCredentialsToken,
   isRestrictedCharactersInName,
-  getStatusCondition
+  getStatusCondition,
+  getPropertyTitles,
+  getSecondaryPropertiesWithInvalidDefinition,
+  getSecondaryTypeProperties,
+  getUpdatedSecondaryProperties
 } = require("./util/index");
 const {
   getDraftAttachments,
   getDraftAttachmentsForUpID,
+  getFileNameForAttachmentID,
+  getPropertiesForID,
   getURLsToDeleteFromAttachments,
   getURLsToDeleteFromDraftAttachments,
   getURLToDeleteFromDraftAttachments,
@@ -33,7 +38,23 @@ const {
   updateAttachmentInDraft,
   setRepositoryId
 } = require("../lib/persistence");
-const { duplicateDraftFileErr, renameFileErr, virusFileErr, duplicateFileErr, versionedRepositoryErr, otherFileErr, userDoesNotHaveRequiredScope, userNotAuthorisedError, renameOtherFilesErr, nameConstrainErr } = require("./util/messageConsts");
+const {
+  duplicateDraftFileErr,
+  renameFileErr,
+  virusFileErr,
+  duplicateFileErr,
+  versionedRepositoryErr,
+  otherFileErr,
+  userDoesNotHaveRequiredScope,
+  userNotAuthorisedError,
+  renameOtherFilesErr,
+  nameConstrainErr,
+  sdmRolesErrorMessage,
+  unsupportedProperties,
+  noSDMRolesErrorMessage,
+  unsupportedPropertiesErrorMessage,
+  badRequestErrorMessage
+} = require("./util/messageConsts");
 
 module.exports = class SDMAttachmentsService extends (
   require("@cap-js/attachments/lib/basic")
@@ -77,45 +98,304 @@ module.exports = class SDMAttachmentsService extends (
 
   async renameHandler(req) {
     const { repositoryId } = getConfigurations();
-    const attachments = cds.model.definitions[req.query.target.name + ".attachments"];
-    const attachment_val = await getDraftAttachments(attachments, req, repositoryId);
+    const attachmentsEntity = cds.model.definitions[req.query.target.name + ".attachments"];
+    const attachment_val = await getDraftAttachments(attachmentsEntity, req, repositoryId);
 
     if (attachment_val.length > 0) {
-      await this.isFileNameDuplicateInDrafts(attachment_val, req);
-
       const token = await fetchAccessToken(
         this.creds,
         req.user.tokenInfo.getTokenValue()
       );
+      await this.isFileNameDuplicateInDrafts(attachment_val, req);
+
+      const propertyTitles = getPropertyTitles(attachmentsEntity, attachment_val[0]);
+      const secondaryPropertiesWithInvalidDefinitions =
+              getSecondaryPropertiesWithInvalidDefinition(
+                attachmentsEntity, attachment_val[0]);
+      
+      const secondaryTypeProperties = getSecondaryTypeProperties(attachmentsEntity, attachment_val[0]);
+      
       let attachment_val_rename = [];
       let draft_attachments = [];
       draft_attachments = attachment_val.filter(attachment => attachment.HasActiveEntity === false);
       attachment_val_rename = attachment_val.filter(attachment => attachment.HasActiveEntity === true);
 
-      const attachmentIDs = attachment_val_rename.map(attachment => attachment.ID);
-      let modifiedAttachments = [];
+      let allErrors = [];
 
-      modifiedAttachments = await checkAttachmentsToRename(attachment_val_rename, attachmentIDs, attachments)
-
-      draft_attachments.forEach( attachment => {
-        const filenameInDraft = attachment.filename;
-        const objectId = attachment.url;
-        const attachmentData = this.getAttachementDataInSDM(this.creds.uri, token, objectId);
-        const filenameInSDM = attachmentData.filename;
-        if(filenameInDraft !== filenameInSDM){
-          modifiedAttachments.push({ID:attachment.ID, url: attachment.url, name: filenameInDraft, prevname: filenameInSDM, folderId:attachmentData.folderId});
-        }
-      });
-
-      let errorMessage = ""
-      if(modifiedAttachments.length>0){
-        errorMessage =  await this.rename(modifiedAttachments, token, req)
+      // Updating draft attachments
+      for (const attachment of draft_attachments) {
+        const errorResponse = await this.updateDraftAttachments(req, token, attachment, attachmentsEntity, secondaryPropertiesWithInvalidDefinitions, secondaryTypeProperties);
+        allErrors = allErrors.concat(errorResponse);
       }
+
+      // Updating non-draft attachments
+      for (const attachment of attachment_val_rename) {
+        const errorResponse = await this.updateNonDraftAttachments(req, token, attachment, attachmentsEntity, secondaryPropertiesWithInvalidDefinitions, secondaryTypeProperties);
+        allErrors = allErrors.concat(errorResponse);
+      }
+
+      this.clearSecondaryPropertiesCache(repositoryId);
       
+      const errorMessage = this.handleWarning(allErrors, propertyTitles);
       if(errorMessage.length != 0){
         req.warn(500, errorMessage); 
+      } 
+    }
+  }
+
+  async updateNonDraftAttachments(req, token, attachment, attachmentsEntity, secondaryPropertiesWithInvalidDefinitions, secondaryTypeProperties) {
+    let failedReq = [];
+    const fileNameInDB = await getFileNameForAttachmentID(attachmentsEntity, attachment.ID);
+    // Fetching the values of the properties from the DB
+    const propertiesInDB = await getPropertiesForID(attachmentsEntity, attachment.ID, secondaryTypeProperties);
+    const updatedSecondaryProperties = getUpdatedSecondaryProperties(attachment, secondaryTypeProperties, propertiesInDB);
+    const filenameInRequest = attachment.filename;
+
+    if (isRestrictedCharactersInName(filenameInRequest)) {
+      failedReq.push({typeOfError: 'restricted characters', name: filenameInRequest});
+      this.replacePropertiesInAttachment(
+        req, attachment.ID, fileNameInDB, propertiesInDB, secondaryTypeProperties);
+      return failedReq;
+    }
+    if (fileNameInDB == null) {
+      if (filenameInRequest != null) {
+        updatedSecondaryProperties["cmis:name"] = filenameInRequest;
+      } else {
+        throw new Error("Filename cannot be empty");
+      }
+    } else {
+      if (filenameInRequest == null) {
+        throw new Error("Filename cannot be empty");
+      } else if (fileNameInDB !== filenameInRequest) {
+        updatedSecondaryProperties["cmis:name"] = filenameInRequest;
       }
     }
+    if (Object.keys(updatedSecondaryProperties).length > 0) {
+      try {
+        const responseCode = await updateAttachment(req, attachment, this.creds, token, updatedSecondaryProperties, secondaryPropertiesWithInvalidDefinitions);
+    
+        switch (responseCode) {
+          case 403:
+            // SDM Roles for user are missing
+            failedReq.push({typeOfError: 'no sdm roles', name: filenameInRequest});
+            this.replacePropertiesInAttachment(req, attachment.ID, fileNameInDB, propertiesInDB, secondaryTypeProperties);
+            break;
+    
+          case 409:
+            failedReq.push({typeOfError: 'duplicate', name: filenameInRequest});
+            this.replacePropertiesInAttachment(req, attachment.ID, fileNameInDB, propertiesInDB, secondaryTypeProperties);
+            break;
+    
+          case 404:
+            failedReq.push({typeOfError:'not found', name: filenameInRequest});
+            this.replacePropertiesInAttachment(req, attachment.ID, fileNameInDB, propertiesInDB, secondaryTypeProperties);
+            break;
+    
+          case 200:
+          case 201:
+            // Success cases, do nothing
+            break;
+    
+          default:
+            throw new Error(sdmRolesErrorMessage);
+        }
+      } catch (e) {
+        // This exception is thrown when there are unsupported properties in the request
+        if (e.message.startsWith(unsupportedProperties)) {
+          const unsupportedDetails = e.message.substring(unsupportedProperties.length).trim();
+          failedReq.push({ typeOfError: 'unsupported properties', details: unsupportedDetails });
+          this.replacePropertiesInAttachment(req, attachment.ID, fileNameInDB, propertiesInDB, secondaryTypeProperties);
+        } else {
+          failedReq.push({ typeOfError: 'bad request', name: filenameInRequest, message: e.message });
+          this.replacePropertiesInAttachment(req, attachment.ID, fileNameInDB, propertiesInDB, secondaryTypeProperties);
+        }
+      }
+    }
+
+    return failedReq;
+  }
+
+  async updateDraftAttachments(req, token, attachment, attachmentsEntity, secondaryPropertiesWithInvalidDefinitions, secondaryTypeProperties) {
+    let failedReq = [];
+    // Fetching the values of the properties from the DB
+    const attachmentData = await this.getAttachementDataInSDM(this.creds.uri, token, attachment.url);
+    const filenameInSDM = attachmentData.filename;
+    const propertiesInDB = await getPropertiesForID(attachmentsEntity, attachment.ID, secondaryTypeProperties);
+    const updatedSecondaryProperties = getUpdatedSecondaryProperties(attachment, secondaryTypeProperties, propertiesInDB);
+    const filenameInRequest = attachment.filename;
+
+    if (isRestrictedCharactersInName(filenameInRequest)) {
+      failedReq.push({typeOfError:'restricted characters', filenameInRequest});
+      this.replacePropertiesInAttachment(
+        req, attachment.ID, filenameInSDM, propertiesInDB, secondaryTypeProperties);
+      return failedReq;
+    }
+    if (filenameInRequest == null) {
+      req.reject(400, "Filename cannot be empty");
+    } else if (filenameInSDM !== filenameInRequest) {
+      updatedSecondaryProperties["cmis:name"] = filenameInRequest;
+    }
+    if (Object.keys(updatedSecondaryProperties).length > 0) {
+      try {
+        const responseCode = await updateAttachment(req, attachment, this.creds, token, updatedSecondaryProperties, secondaryPropertiesWithInvalidDefinitions);
+
+        switch (responseCode) {
+          case 403:
+            // SDM Roles for user are missing
+            failedReq.push({typeOfError: 'no sdm roles', name: filenameInRequest});
+            this.replacePropertiesInAttachment(req, attachment.ID, filenameInSDM, propertiesInDB, secondaryTypeProperties);
+            break;
+    
+          case 409:
+            failedReq.push({typeOfError: 'duplicate', name: filenameInRequest});
+            this.replacePropertiesInAttachment(req, attachment.ID, filenameInSDM, propertiesInDB, secondaryTypeProperties);
+            break;
+    
+          case 404:
+            failedReq.push({typeOfError: 'not found', name: filenameInRequest});
+            this.replacePropertiesInAttachment(req, attachment.ID, filenameInSDM, propertiesInDB, secondaryTypeProperties);
+            break;
+    
+          case 200:
+          case 201:
+            // Success cases, do nothing
+            break;
+    
+          default:
+            throw new Error(sdmRolesErrorMessage);
+        }
+      } catch (e) {
+        // This exception is thrown when there are unsupported properties in the request
+        if (e.message.startsWith(unsupportedProperties)) {
+          const unsupportedDetails = e.message.substring(unsupportedProperties.length).trim();
+          failedReq.push({ typeOfError: 'unsupported properties', details: unsupportedDetails });
+          this.replacePropertiesInAttachment(req, attachment.ID, filenameInSDM, propertiesInDB, secondaryTypeProperties);
+        } else {
+          failedReq.push({ typeOfError: 'bad request', name: filenameInRequest, message: e.message });
+          this.replacePropertiesInAttachment(req, attachment.ID, filenameInSDM, propertiesInDB, secondaryTypeProperties);
+        }
+      }
+    }
+
+    return failedReq;
+  }
+
+  replacePropertiesInAttachment(req, id, fileName, propertiesInDB, secondaryTypeProperties) {
+    const attachment = req.data.attachments.find(element => element.ID === id);
+    if (!attachment) {
+      return;
+    }
+
+    if (propertiesInDB) {
+      let i = 0;
+      for (const [dbKey, dbValue] of Object.entries(propertiesInDB)) {
+        // Use Map.prototype.entries() to find the key in secondaryTypeProperties
+        const secondaryKey = [...secondaryTypeProperties.entries()]
+          .find(([_, value]) => value === dbKey)?.[0];
+  
+        if (secondaryKey) {
+          attachment[secondaryKey] = dbValue;
+        }
+      }
+    }
+  
+    // Replace the file name in the attachment
+    attachment.filename = fileName;
+  }
+
+  clearSecondaryPropertiesCache(repositoryId) {
+    const cacheKey = `validSecondaryProperties_${repositoryId}`;
+    
+    // Check if the cache exists and remove the key
+    if (cache.has(cacheKey)) {
+      cache.del(cacheKey); // Emptying cache after attachments are updated in loop
+    }
+  }
+
+  handleWarning(allErrors, propertyTitles) {
+    const restrictedCharacters = allErrors.filter(error =>
+      error.typeOfError === 'restricted characters'
+    );
+    
+    const duplicate = allErrors.filter(error => 
+      error.typeOfError === 'duplicate'
+    );
+    const duplicateNames = duplicate.map(attachment => attachment.name);
+    
+    const notFound = allErrors.filter(error => 
+      error.typeOfError === 'not found'
+    );
+    const notFoundNames = notFound.map(attachment => attachment.name);
+
+    const noSDMRoles = allErrors.filter(error =>
+      error.typeOfError === 'no sdm roles'
+    );
+    const noSDMRolesNames = noSDMRoles.map(attachment => attachment.name);
+
+    const unsupportedProperties = allErrors.filter(error =>
+      error.typeOfError === 'unsupported properties'
+    );
+    const unsupportedPropertiesDetails = unsupportedProperties.map(attachment => attachment.details);
+
+    const badRequest = allErrors.filter(error =>
+      error.typeOfError === 'bad request'
+    );
+    
+    const otherErrors = allErrors.filter(error => 
+      error.typeOfError !== 'duplicate'
+      && error.typeOfError !== 'not found'
+      && error.typeOfError !== 'restricted characters'
+      && error.typeOfError !== 'no sdm roles'
+      && error.typeOfError !== 'unsupported properties'
+      && error.typeOfError !== 'bad request'
+    );
+    const otherNames = otherErrors.map(attachment => attachment.name);
+    const otherMessages = otherErrors.map(attachment => attachment.typeOfError);
+    
+
+    let errorResponse = "";
+    if (restrictedCharacters.length > 0) {
+      errorResponse += nameConstrainErr(restrictedCharacters.map(attachment => attachment.name), "Update");
+    }
+    if (duplicateNames.length > 0) {
+      errorResponse += renameFileErr(duplicateNames, getStatusCondition(409));
+    }
+    if (notFoundNames.length > 0) {
+      errorResponse += renameFileErr(notFoundNames, getStatusCondition(404));
+    }
+    if (noSDMRolesNames.length > 0) {
+      errorResponse += noSDMRolesErrorMessage(noSDMRolesNames, "update");
+    }
+    if (unsupportedPropertiesDetails.length > 0) {
+      const invalidPropertyNames = [];
+      const uniqueValues = new Set();
+    
+      // Extract unique values from filesWithUnsupportedProperties
+      unsupportedPropertiesDetails.forEach((str) => {
+        const values = str.split(",");
+        values.forEach((value) => {
+          uniqueValues.add(value.trim());
+        });
+      });
+    
+      // Convert the Set to an array and map property titles
+      const propertiesList = Array.from(uniqueValues);
+      propertiesList.forEach((file) => {
+        invalidPropertyNames.push(propertyTitles[file]);
+      });
+    
+      // Warn if invalid property names exist
+      if (invalidPropertyNames.length > 0) {
+        errorResponse += unsupportedPropertiesErrorMessage(invalidPropertyNames);
+      }
+    }
+    if (badRequest.length > 0) {
+      errorResponse += badRequestErrorMessage(badRequest);
+    }
+    if (otherNames.length > 0) {
+      errorResponse += renameOtherFilesErr(otherNames, otherMessages);
+    }
+    return errorResponse;
   }
 
   async getAttachementDataInSDM(uri, token, objectId) {
@@ -156,48 +436,6 @@ module.exports = class SDMAttachmentsService extends (
       }
       req.data.content = null;
     }
-  }
-
-  async rename(modifiedAttachments, token, req){
-    const failedReq = await this.onRename(
-      modifiedAttachments,
-      this.creds,
-      token,
-      req
-    );
-
-    const restrictedCharacters = failedReq.filter(attachment =>
-      attachment.typeOfError === 'restricted characters'
-    );
-    const duplicate = failedReq.filter(attachment => 
-      attachment.typeOfError === 'duplicate'
-    );
-    const duplicateNames = duplicate.map(attachment => attachment.name);
-    const notFound = failedReq.filter(attachment => 
-      attachment.typeOfError === 'not found'
-    );
-    const notFoundNames = notFound.map(attachment => attachment.name);
-    const otherErrors = failedReq.filter(attachment => 
-      attachment.typeOfError !== 'duplicate' && attachment.typeOfError !== 'not found' && attachment.typeOfError !== 'restricted characters'
-    );
-    const otherNames = otherErrors.map(attachment => attachment.name);
-    const otherMessages = otherErrors.map(attachment => attachment.typeOfError);
-    
-
-    let errorResponse = "";
-    if (restrictedCharacters.length > 0) {
-      errorResponse += nameConstrainErr(restrictedCharacters.map(attachment => attachment.name), "Rename");
-    }
-    if (duplicateNames.length > 0) {
-      errorResponse += renameFileErr(duplicateNames, getStatusCondition(409));
-    }
-    if (notFoundNames.length > 0) {
-      errorResponse += renameFileErr(notFoundNames, getStatusCondition(404));
-    }
-    if (otherNames.length > 0) {
-      errorResponse += renameOtherFilesErr(otherNames, otherMessages);
-    }
-    return errorResponse;
   }
 
   async create(attachment_val_create, attachments, req, token){
@@ -444,57 +682,6 @@ module.exports = class SDMAttachmentsService extends (
         }
       })
     );
-  }
-
-  async onRename(modifiedAttachments, credentials, token, req) {
-    let emptyNameExists = modifiedAttachments.some(attachment => attachment.name === "");
-    if(emptyNameExists) {
-      throw new Error("Filename cannot be empty");
-    }
-    let failedReq = [];
-
-    await Promise.all(
-      modifiedAttachments.map(async (a) => {
-        if (isRestrictedCharactersInName(a.name)) {
-          failedReq.push({typeOfError:'restricted characters',name:a.name});
-          const attachmentData = await this.getAttachementDataInSDM(this.creds.uri, token, a.url);
-          const filenameInSDM = attachmentData.filename;
-          const attachment = req.data.attachments.find(element => element.ID === a.ID)
-          if (attachment) {
-            attachment.filename = filenameInSDM;
-          }
-        } else {
-          const response = await renameAttachment(
-            a,
-            credentials,
-            token
-          );
-
-          if (response.status != 200) {
-            //modify req.data.attachments
-            for(let i = 0; i < req.data.attachments.length; i++) {
-              let attachmentUpdate = req.data.attachments[i];
-              if(a.ID == attachmentUpdate.ID){
-                attachmentUpdate.filename = a.prevname;
-                req.data.attachments[i] = attachmentUpdate;
-              }
-            }
-            if (response.status == 409){
-              failedReq.push({typeOfError:'duplicate',name:a.name})
-            }
-            else if (response.status == 404){
-              failedReq.push({typeOfError:'not found',name:a.prevname})
-            }
-            else{
-              failedReq.push({typeOfError:response.message,name:a.name})
-            }
-          }
-        }
-      })
-    );
-
-
-    return failedReq;
   }
 
   async handleRequest(response, objectId) {

--- a/lib/util/index.js
+++ b/lib/util/index.js
@@ -5,10 +5,6 @@ const NodeCache = require("node-cache");
 const cache = new NodeCache();
 const { sdmAnnotationAdditionalpropertyName, sdmAnnotationAdditionalproperty } = require("./messageConsts");
 
-// const {
-//   getExistingAttachments
-// } = require("../../lib/persistence");
-
 async function fetchAccessToken(credentials, jwt) {
   let decoded_token_jwt = decodeAccessToken(jwt);
    let subdomain = cds.context.user?.tokenInfo?.getPayload()?.ext_attr?.zdn;
@@ -122,22 +118,6 @@ function getConfigurations() {
   }
 }
 
-
-// async function checkAttachmentsToRename(attachment_val_rename, attachmentIDs, attachments){
-//   let modifiedAttachments = [];
-//   if(attachment_val_rename.length>0){
-//     const matchedAttachments = await getExistingAttachments(attachmentIDs, attachments);
-//     attachment_val_rename.forEach(draftAttachment => {
-//       const correspondingAttachment = matchedAttachments.find(attachment => attachment.ID === draftAttachment.ID);
-//       if(correspondingAttachment && correspondingAttachment.filename !== draftAttachment.filename) {
-//         modifiedAttachments.push({ID:draftAttachment.ID, url: draftAttachment.url, name: draftAttachment.filename, prevname: correspondingAttachment.filename,folderId:correspondingAttachment.folderId});
-//       }
-//     });
-//   }
-
-//   return modifiedAttachments
-// }
-
 function isRestrictedCharactersInName(filename) {
   const regex = /[/\\]/;
   return regex.test(filename);
@@ -166,7 +146,6 @@ function getPropertyTitles(attachmentEntity, attachment) {
       continue;
     }
 
-    //const propertyName = extractPropertyName(element);
     const propertyName = element[sdmAnnotationAdditionalpropertyName] ? element[sdmAnnotationAdditionalpropertyName] : null;
     // Use the title annotation if available, otherwise fallback to the element name
     const title = element['@title'] ? element['@title'] : element.name;
@@ -179,19 +158,7 @@ function getPropertyTitles(attachmentEntity, attachment) {
   return titleMap;
 }
 
-// function extractPropertyName(element) {
-//   // Check both old and new SDM annotations to track titles for properties needing error handling
-//   if (element[sdmAnnotationAdditionalpropertyName]) {
-//     return element[sdmAnnotationAdditionalpropertyName];
-//   } else if (element[sdmAnnotationAdditionalproperty]) {
-//     return element.name; // If the user has not specified a title for the column
-//   }
-//   return null;
-// }
-
-/**
- * Identify incorrectly defined properties in the CDS file to group them with unsupported ones where "MCM" is not true.
- */
+//Identify incorrectly defined properties in the CDS file to group them with unsupported ones where "MCM" is not true.
 function getSecondaryPropertiesWithInvalidDefinition(attachmentEntity, attachment) {
   const invalidProperties = {};
 
@@ -226,17 +193,10 @@ function getSecondaryTypeProperties(attachmentEntity, attachment) {
     keysList.forEach((key) => {
       const element = attachmentEntity.elements[key];
       if (element) {
-        // Checking the SDM Annotation, both the old (outdated method) and the correct method.
-        //const annotation = element[sdmAnnotationAdditionalproperty];
+        // Check if the element has the new SDM annotation for additional properties
         const nameAnnotation = element[sdmAnnotationAdditionalpropertyName];
 
-        // if (annotation) {
-        //   // If the property was defined using the old method, we will use the actual name of the property
-        //   secondaryTypeProperties.set(element.name, element.name);
-        // }
-
         if (nameAnnotation) {
-          // If the property was defined using the new method, we will use the name specified in the annotation
           secondaryTypeProperties.set(element.name, nameAnnotation);
         }
       }
@@ -246,9 +206,7 @@ function getSecondaryTypeProperties(attachmentEntity, attachment) {
   return secondaryTypeProperties;
 }
 
-/**
- * Get updated secondary properties by comparing the current attachment values with the database values.
- */
+//Get updated secondary properties by comparing the current attachment values with the database values.
 function getUpdatedSecondaryProperties(attachment, secondaryTypeProperties, propertiesInDB) {
   const updatedSecondaryProperties = {};
 
@@ -266,9 +224,7 @@ function getUpdatedSecondaryProperties(attachment, secondaryTypeProperties, prop
   return updatedSecondaryProperties;
 }
 
-/**
- * Extracts secondary type IDs from a JSON array and adds them to the result list.
- */
+//Extracts secondary type IDs from a JSON array and adds them to the result list.
 function extractSecondaryTypeIds(jsonArray, result) {
   for (let i = 0; i < jsonArray.length; i++) {
     const jsonObject = jsonArray[i];
@@ -286,9 +242,7 @@ function extractSecondaryTypeIds(jsonArray, result) {
   }
 }
 
-/**
- * Checks if the response contains valid secondary properties and updates the list.
- */
+//Checks if the response contains valid secondary properties and updates the list.
 function checkMCM(responseBody, secondaryPropertyIds) {
   let flag = false;
 
@@ -323,9 +277,7 @@ function checkMCM(responseBody, secondaryPropertyIds) {
   return flag;
 }
 
-/**
- * Prepares secondary properties and adds them to the FormData object.
- */
+//Prepares secondary properties and adds them to the FormData object.
 function prepareSecondaryProperties(formData, secondaryProperties) {
   let index = 1;
 

--- a/lib/util/index.js
+++ b/lib/util/index.js
@@ -3,10 +3,11 @@ const cds = require("@sap/cds");
 const requests = xssec.requests;
 const NodeCache = require("node-cache");
 const cache = new NodeCache();
+const { sdmAnnotationAdditionalpropertyName, sdmAnnotationAdditionalproperty } = require("./messageConsts");
 
-const {
-  getExistingAttachments
-} = require("../../lib/persistence");
+// const {
+//   getExistingAttachments
+// } = require("../../lib/persistence");
 
 async function fetchAccessToken(credentials, jwt) {
   let decoded_token_jwt = decodeAccessToken(jwt);
@@ -122,20 +123,20 @@ function getConfigurations() {
 }
 
 
-async function checkAttachmentsToRename(attachment_val_rename, attachmentIDs, attachments){
-  let modifiedAttachments = [];
-  if(attachment_val_rename.length>0){
-    const matchedAttachments = await getExistingAttachments(attachmentIDs, attachments);
-    attachment_val_rename.forEach(draftAttachment => {
-      const correspondingAttachment = matchedAttachments.find(attachment => attachment.ID === draftAttachment.ID);
-      if(correspondingAttachment && correspondingAttachment.filename !== draftAttachment.filename) {
-        modifiedAttachments.push({ID:draftAttachment.ID, url: draftAttachment.url, name: draftAttachment.filename, prevname: correspondingAttachment.filename,folderId:correspondingAttachment.folderId});
-      }
-    });
-  }
+// async function checkAttachmentsToRename(attachment_val_rename, attachmentIDs, attachments){
+//   let modifiedAttachments = [];
+//   if(attachment_val_rename.length>0){
+//     const matchedAttachments = await getExistingAttachments(attachmentIDs, attachments);
+//     attachment_val_rename.forEach(draftAttachment => {
+//       const correspondingAttachment = matchedAttachments.find(attachment => attachment.ID === draftAttachment.ID);
+//       if(correspondingAttachment && correspondingAttachment.filename !== draftAttachment.filename) {
+//         modifiedAttachments.push({ID:draftAttachment.ID, url: draftAttachment.url, name: draftAttachment.filename, prevname: correspondingAttachment.filename,folderId:correspondingAttachment.folderId});
+//       }
+//     });
+//   }
 
-  return modifiedAttachments
-}
+//   return modifiedAttachments
+// }
 
 function isRestrictedCharactersInName(filename) {
   const regex = /[/\\]/;
@@ -150,12 +151,208 @@ function getStatusCondition(statusCode) {
   }
 }
 
+function getPropertyTitles(attachmentEntity, attachment) {
+  const titleMap = {};
+
+  if (!attachmentEntity) {
+    return titleMap;
+  }
+
+  const entity = attachmentEntity;
+  for (const key of Object.keys(attachment)) {
+    const element = entity.elements[key];
+    // Skip if the element is undefined
+    if (!element) {
+      continue;
+    }
+
+    //const propertyName = extractPropertyName(element);
+    const propertyName = element[sdmAnnotationAdditionalpropertyName] ? element[sdmAnnotationAdditionalpropertyName] : null;
+    // Use the title annotation if available, otherwise fallback to the element name
+    const title = element['@title'] ? element['@title'] : element.name;
+
+    if (propertyName && title) {
+      titleMap[propertyName] = title;
+    }
+  }
+
+  return titleMap;
+}
+
+// function extractPropertyName(element) {
+//   // Check both old and new SDM annotations to track titles for properties needing error handling
+//   if (element[sdmAnnotationAdditionalpropertyName]) {
+//     return element[sdmAnnotationAdditionalpropertyName];
+//   } else if (element[sdmAnnotationAdditionalproperty]) {
+//     return element.name; // If the user has not specified a title for the column
+//   }
+//   return null;
+// }
+
+/**
+ * Identify incorrectly defined properties in the CDS file to group them with unsupported ones where "MCM" is not true.
+ */
+function getSecondaryPropertiesWithInvalidDefinition(attachmentEntity, attachment) {
+  const invalidProperties = {};
+
+  if (!attachmentEntity) {
+    return invalidProperties;
+  }
+
+  const keysList = Object.keys(attachment);
+
+  for (const key of keysList) {
+
+    const element = attachmentEntity.elements[key];
+    if (element) {
+      // Checking the outdated/old SDM Annotation
+      const sdmAnnotation = element[sdmAnnotationAdditionalproperty];
+      if (sdmAnnotation) {
+        const titleAnnotation = element['@title'];
+        const title = titleAnnotation ? titleAnnotation : element.name; // Fallback to element name if title is not defined
+        invalidProperties[key] = title;
+      }
+    }
+  }
+
+  return invalidProperties;
+}
+
+function getSecondaryTypeProperties(attachmentEntity, attachment) {
+  const keysList = Object.keys(attachment);
+  const secondaryTypeProperties = new Map();
+  
+  if (attachmentEntity) {
+    keysList.forEach((key) => {
+      const element = attachmentEntity.elements[key];
+      if (element) {
+        // Checking the SDM Annotation, both the old (outdated method) and the correct method.
+        //const annotation = element[sdmAnnotationAdditionalproperty];
+        const nameAnnotation = element[sdmAnnotationAdditionalpropertyName];
+
+        // if (annotation) {
+        //   // If the property was defined using the old method, we will use the actual name of the property
+        //   secondaryTypeProperties.set(element.name, element.name);
+        // }
+
+        if (nameAnnotation) {
+          // If the property was defined using the new method, we will use the name specified in the annotation
+          secondaryTypeProperties.set(element.name, nameAnnotation);
+        }
+      }
+    });
+  }
+
+  return secondaryTypeProperties;
+}
+
+/**
+ * Get updated secondary properties by comparing the current attachment values with the database values.
+ */
+function getUpdatedSecondaryProperties(attachment, secondaryTypeProperties, propertiesInDB) {
+  const updatedSecondaryProperties = {};
+
+  // Compare the current values with the database values
+  for (const [property, key] of secondaryTypeProperties.entries()) {
+    const currentValue = attachment[property];
+    const dbValue = propertiesInDB[key];
+
+    if ((currentValue == null && dbValue != null) || 
+      (currentValue != null && currentValue.toString() != dbValue)) { 
+      updatedSecondaryProperties[key] = currentValue != null ? currentValue.toString() : null;
+    }
+  }
+
+  return updatedSecondaryProperties;
+}
+
+/**
+ * Extracts secondary type IDs from a JSON array and adds them to the result list.
+ */
+function extractSecondaryTypeIds(jsonArray, result) {
+  for (let i = 0; i < jsonArray.length; i++) {
+    const jsonObject = jsonArray[i];
+
+    // Extract and store the type ID if it exists
+    if (jsonObject.type && jsonObject.type.id) {
+      const secondaryType = jsonObject.type.id;
+      result.push(secondaryType);
+    }
+
+    // If this object has children, recursively process them
+    if (jsonObject.children) {
+      extractSecondaryTypeIds(jsonObject.children, result);
+    }
+  }
+}
+
+/**
+ * Checks if the response contains valid secondary properties and updates the list.
+ */
+function checkMCM(responseBody, secondaryPropertyIds) {
+  let flag = false;
+
+  if (!responseBody || responseBody.trim() === "") {
+    return flag;
+  }
+
+  const jsonObject = JSON.parse(responseBody);
+
+  if (!jsonObject.hasOwnProperty("propertyDefinitions")) {
+    return flag;
+  }
+
+  const propertyDefinitions = jsonObject.propertyDefinitions;
+
+  if (!propertyDefinitions) {
+    return flag;
+  }
+
+  for (const key in propertyDefinitions) {
+    if (propertyDefinitions.hasOwnProperty(key)) {
+      const property = propertyDefinitions[key];
+      const miscellaneous = property?.["mcm:miscellaneous"];
+
+      if (miscellaneous && miscellaneous.isPartOfTable === "true") {
+        secondaryPropertyIds.push(key);
+        flag = true;
+      }
+    }
+  }
+
+  return flag;
+}
+
+/**
+ * Prepares secondary properties and adds them to the FormData object.
+ */
+function prepareSecondaryProperties(formData, secondaryProperties) {
+  let index = 1;
+
+  for (const [key, value] of Object.entries(secondaryProperties)) {
+    if (key === "filename") {
+      formData.append(`propertyId[${index}]`, "cmis:name");
+      formData.append(`propertyValue[${index}]`, value);
+    } else {
+      formData.append(`propertyId[${index}]`, key);
+      formData.append(`propertyValue[${index}]`, value);
+    }
+    index++;
+  }
+}
+
 module.exports = {
   fetchAccessToken,
   getConfigurations,
-  checkAttachmentsToRename,
   isRepositoryVersioned,
   getClientCredentialsToken,
   isRestrictedCharactersInName,
-  getStatusCondition
+  getStatusCondition,
+  getPropertyTitles,
+  getSecondaryPropertiesWithInvalidDefinition,
+  getSecondaryTypeProperties,
+  getUpdatedSecondaryProperties,
+  extractSecondaryTypeIds,
+  checkMCM,
+  prepareSecondaryProperties
 };

--- a/lib/util/index.js
+++ b/lib/util/index.js
@@ -226,15 +226,13 @@ function getUpdatedSecondaryProperties(attachment, secondaryTypeProperties, prop
 
 //Extracts secondary type IDs from a JSON array and adds them to the result list.
 function extractSecondaryTypeIds(jsonArray, result) {
-  for (let i = 0; i < jsonArray.length; i++) {
-    const jsonObject = jsonArray[i];
-
+  for (const jsonObject of jsonArray) {
     // Extract and store the type ID if it exists
     if (jsonObject.type && jsonObject.type.id) {
       const secondaryType = jsonObject.type.id;
       result.push(secondaryType);
     }
-
+  
     // If this object has children, recursively process them
     if (jsonObject.children) {
       extractSecondaryTypeIds(jsonObject.children, result);
@@ -252,7 +250,7 @@ function checkMCM(responseBody, secondaryPropertyIds) {
 
   const jsonObject = JSON.parse(responseBody);
 
-  if (!jsonObject.hasOwnProperty("propertyDefinitions")) {
+  if (!Object.hasOwn(jsonObject, "propertyDefinitions")) {
     return flag;
   }
 
@@ -263,10 +261,10 @@ function checkMCM(responseBody, secondaryPropertyIds) {
   }
 
   for (const key in propertyDefinitions) {
-    if (propertyDefinitions.hasOwnProperty(key)) {
+    if (Object.hasOwn(propertyDefinitions, key)) {
       const property = propertyDefinitions[key];
       const miscellaneous = property?.["mcm:miscellaneous"];
-
+    
       if (miscellaneous && miscellaneous.isPartOfTable === "true") {
         secondaryPropertyIds.push(key);
         flag = true;

--- a/lib/util/messageConsts.js
+++ b/lib/util/messageConsts.js
@@ -11,13 +11,13 @@ module.exports.duplicateFileErr = (duplicateFiles) => {
 module.exports.renameFileErr = (duplicateFiles, statusCondition) => {
   const bulletPoints = duplicateFiles.map(file => `• ${file}`).join('\n');
   if (statusCondition === "don't") {
-    return `The following files could not be renamed as they ${statusCondition} exist:\n${bulletPoints}\n\nDelete and upload the files again.\n`;
+    return `The following files could not be updated as they ${statusCondition} exist:\n${bulletPoints}\n\nDelete and upload the files again.\n`;
   }
-  return `The following files could not be renamed as they ${statusCondition} exist:\n${bulletPoints}\n`;
+  return `The following files could not be updated as they ${statusCondition} exist:\n${bulletPoints}\n`;
 };
 module.exports.renameOtherFilesErr = (otherFiles, otherFileMessages) => {
   const bulletPoints = otherFiles.map((file, index) => `• ${file} : ${otherFileMessages[index]}`).join('\n');
-  return `The following files could not be renamed:\n${bulletPoints}\n`;
+  return `The following files could not be updated:\n${bulletPoints}\n`;
 };
 module.exports.otherFileErr = (otherFiles) => {
   const message = otherFiles.map(file => `${file}`).join('\n');
@@ -25,6 +25,7 @@ module.exports.otherFileErr = (otherFiles) => {
 };
 module.exports.versionedRepositoryErr = 'Attachments are not supported for a versioned repository.';
 module.exports.userNotAuthorisedError  = 'You do not have the required permissions to upload attachments. Please contact your administrator for access.';
+module.exports.sdmMissingRolesExceptionMsg = 'You do not have the required permissions to update attachments. Please contact your administrator for access.';
 module.exports.userDoesNotHaveRequiredScope = 'User does not have the required scope';
 module.exports.errorMessage = 'An error occurred';
 module.exports.nameConstrainErr = (fileNameWithRestrictedCharacters, operation) => {
@@ -33,3 +34,60 @@ module.exports.nameConstrainErr = (fileNameWithRestrictedCharacters, operation) 
   const message = `${prefixMessage}${bulletPoints}\n\nRename the file(s) and try again.\n`;
   return message;
 };
+module.exports.sdmAnnotationAdditionalpropertyName = "@SDM.Attachments.AdditionalProperty.name";
+module.exports.sdmAnnotationAdditionalproperty = "@SDM.Attachments.AdditionalProperty";
+module.exports.updateAttachmentError = "Could not update the attachment";
+module.exports.sdmRolesErrorMessage = "Unable to rename the file due to an error at the server";
+module.exports.unsupportedProperties = "Unsupported properties";
+module.exports.noSDMRolesErrorMessage = (files, operation) => {
+  // Create the base message
+  const prefixMessage = `Could not ${operation} the following files. \n\n`;
+  // Initialize the message with the formatted prefix
+  let bulletPoints = prefixMessage;
+  // Append each file name and its error message
+  files.forEach((item) => {
+    bulletPoints += `\t• ${item}\n`;
+  });
+  bulletPoints += '\n';
+  if (operation === 'create') {
+    bulletPoints += this.userNotAuthorisedError;
+  } else {
+    bulletPoints += this.sdmMissingRolesExceptionMsg;
+  }
+  return bulletPoints;
+}
+module.exports.unsupportedPropertiesErrorMessage = (propertiesList) => {
+ // Create the base message
+ const prefixMessage = "The following secondary properties are not supported:\n\n";
+
+ // Initialize the message with the prefix
+ let bulletPoints = prefixMessage;
+
+ // Append each unsupported property to the message
+ propertiesList.forEach((property) => {
+   bulletPoints += `\t• ${property}\n`;
+ });
+
+ // Append the closing message
+ bulletPoints += "\nPlease contact your administrator for assistance with any necessary adjustments.";
+
+ return bulletPoints;
+}
+module.exports.badRequestErrorMessage = (badRequest) => {
+
+  // Create the base message
+  const prefixMessage = "Could not update the following files:\n\n";
+
+  // Initialize the message with the prefix
+  let bulletPoints = prefixMessage;
+
+  // Append each file name and its error message to the message
+  badRequest.forEach((request) => {
+    bulletPoints += `\t• ${request.name} : ${request.message}\n`;
+  });
+
+  // Append the closing message
+  bulletPoints += "\nPlease try again.";
+
+  return bulletPoints;
+}

--- a/test/lib/handler/index.test.js
+++ b/test/lib/handler/index.test.js
@@ -521,6 +521,7 @@ describe("handlers", () => {
     let req, attachment, credentials, token, updatedSecondaryProperties, secondaryPropertiesWithInvalidDefinitions;
   
     beforeEach(() => {
+      jest.resetAllMocks();
       jest.clearAllMocks();
   
       req = { reject: jest.fn() };
@@ -650,6 +651,70 @@ describe("handlers", () => {
   
       expect(result).toBe(500);
       expect(getConfigurations).toHaveBeenCalledTimes(1);
+    });
+
+    it("should throw an error if invalid secondary properties are found", async () => {
+      const mockResponse = { status: 200 };
+    
+      // Mock axios.get for getSecondaryTypes and getValidSecondaryProperties
+      axios.get.mockImplementation((url) => {
+        if (url.includes("typeDescendants")) {
+          return Promise.resolve({
+            data: [
+              {
+                type: { id: "cmis:secondary" },
+                children: [
+                  { type: { id: "type1" } },
+                  { type: { id: "type2" } },
+                ],
+              },
+            ],
+          });
+        } else if (url.includes("typeDefinition")) {
+          return Promise.resolve({ data: { propertyDefinitions: {} } });
+        }
+      });
+    
+      require("../../../lib/util/index").extractSecondaryTypeIds.mockImplementation((jsonArray, result) => {
+        // Simulate extracting secondary type IDs
+        jsonArray.forEach((item) => {
+          if (item.type && item.type.id) {
+            result.push(item.type.id);
+          }
+        });
+      });
+    
+      // Mock checkMCM to validate secondary properties
+      require("../../../lib/util/index").checkMCM.mockImplementation((responseBody, validSecondaryProperties) => {
+        validSecondaryProperties.push("cmis:name"); // Only "cmis:name" is valid
+        return true;
+      });
+    
+      // Set up secondaryPropertiesWithInvalidDefinitions to match a key in updatedSecondaryProperties
+      const secondaryPropertyInvalidDefinition = {
+        invalidProperty1: "custom:property", // This matches a key in updatedSecondaryProperties
+      };
+    
+      // Mock axios.post for updateServerRequest
+      axios.post.mockResolvedValue(mockResponse);
+    
+      // Act & Assert
+      await expect(
+        updateAttachment(
+          req,
+          attachment,
+          credentials,
+          token,
+          updatedSecondaryProperties,
+          secondaryPropertyInvalidDefinition
+        )
+      ).rejects.toThrow("Unsupported properties custom:property");
+    
+      // Verify that the mocks were called
+      expect(getConfigurations).toHaveBeenCalledTimes(1);
+      expect(axios.get).toHaveBeenCalledTimes(3); // 1 for getSecondaryTypes, 2 for getValidSecondaryProperties
+      expect(require("../../../lib/util/index").checkMCM).toHaveBeenCalledTimes(2);
+      expect(axios.post).toHaveBeenCalledTimes(0); // Request should not be sent due to the error
     });
   
     it("should throw an error if updateServerRequest fails with a 400 status", async () => {

--- a/test/lib/handler/index.test.js
+++ b/test/lib/handler/index.test.js
@@ -1,5 +1,12 @@
 const axios = require("axios");
+const NodeCache = require("node-cache");
 jest.mock("axios");
+jest.mock("node-cache", () => {
+  return jest.fn().mockImplementation(() => ({
+    get: jest.fn(),
+    set: jest.fn(),
+  }));
+});
 let formDataMockedInstances = [];
 
 jest.mock("form-data", () => {
@@ -16,6 +23,9 @@ jest.mock("form-data", () => {
 jest.mock("../../../lib/util/index", () => {
   return {
     getConfigurations: jest.fn().mockReturnValue({ repositoryId: "123" }),
+    prepareSecondaryProperties: jest.fn(), // Add this mock
+    checkMCM: jest.fn(),
+    extractSecondaryTypeIds: jest.fn(),
   };
 });
 const { getConfigurations } = require("../../../lib/util/index");
@@ -28,8 +38,8 @@ const {
   createFolder,
   deleteFolderWithAttachments,
   getAttachment,
-  renameAttachment,
-  getRepositoryInfo
+  getRepositoryInfo,
+  updateAttachment
 } = require("../../../lib/handler/index");
 const { errorMessage } = require("../../../lib/util/messageConsts");
 
@@ -508,29 +518,201 @@ describe("handlers", () => {
     });
   });
 
-  describe("renameAttachment", () => {
+  describe("updateAttachment", () => {
+    let req, attachment, credentials, token, updatedSecondaryProperties, secondaryPropertiesWithInvalidDefinitions;
+  
     beforeEach(() => {
       jest.clearAllMocks();
+  
+      req = { reject: jest.fn() };
+      attachment = { url: "mockObjectId" };
+      credentials = { uri: "http://mock-uri/" };
+      token = "mockToken";
+      updatedSecondaryProperties = { "cmis:name": "newName", "custom:property": "value" };
+      secondaryPropertiesWithInvalidDefinitions = {};
+  
+      getConfigurations.mockReturnValue({ repositoryId: "mockRepoId" });
     });
+  
+    it("should update attachment successfully and return status code", async () => {
+      const mockSecondaryTypes = ["type1", "type2"];
+      const mockValidSecondaryProperties = ["cmis:namemock", "custom:property"];
+      const mockResponse = { status: 200 };
+    
+      // Mock axios.get for getSecondaryTypes and getValidSecondaryProperties
+      axios.get.mockImplementation((url) => {
+        if (url.includes("typeDescendants")) {
+          return Promise.resolve({
+            data: [
+              {
+                type: { id: "cmis:secondary" },
+                children: [
+                  { type: { id: "type1" } },
+                  { type: { id: "type2" } },
+                ],
+              },
+            ],
+          });
+        } else if (url.includes("typeDefinition")) {
+          return Promise.resolve({ data: { propertyDefinitions: {} } });
+        }
+      });
 
-    it("returns response from updateServerRequest without error", async () => {
-      const modifiedAttachments = [{name:"name"}];
-      const credentials = {};
-      const token = "token";
-      axios.post.mockResolvedValue({'status' : 201});
-
-      const result = await renameAttachment(
-        modifiedAttachments,
+      require("../../../lib/util/index").extractSecondaryTypeIds.mockImplementation((jsonArray, result) => {
+        // Simulate extracting secondary type IDs
+        jsonArray.forEach((item) => {
+          if (item.type && item.type.id) {
+            result.push(item.type.id);
+          }
+        });
+      });
+    
+      // Mock checkMCM to validate secondary properties
+      require("../../../lib/util/index").checkMCM.mockImplementation((responseBody, validSecondaryProperties) => {
+        validSecondaryProperties.push("cmis:name", "custom:property");
+        return true;
+      });
+    
+      // Mock axios.post for updateServerRequest
+      axios.post.mockResolvedValue(mockResponse);
+    
+      const result = await updateAttachment(
+        req,
+        attachment,
         credentials,
         token,
+        updatedSecondaryProperties,
+        secondaryPropertiesWithInvalidDefinitions
       );
-      expect(result.status).toEqual(201);
-    });
-
-    it("calls getConfigurations", async () => {
-      await renameAttachment({}, {}, "", {});
-
+    
       expect(getConfigurations).toHaveBeenCalledTimes(1);
+      expect(axios.get).toHaveBeenCalledTimes(3); // 1 for getSecondaryTypes, 2 for getValidSecondaryProperties
+      expect(require("../../../lib/util/index").checkMCM).toHaveBeenCalledTimes(2);
+      expect(axios.post).toHaveBeenCalledTimes(1);
+      expect(result).toBe(200);
+    });
+  
+    it("should throw an error if unsupported properties are found", async () => {
+      const mockSecondaryTypes = ["type1", "type2"];
+      const mockValidSecondaryProperties = ["cmis:name"];
+  
+      // Mock axios.get for getSecondaryTypes and getValidSecondaryProperties
+      axios.get.mockImplementation((url) => {
+        if (url.includes("typeDescendants")) {
+          return Promise.resolve({
+            data: [
+              { type: { id: "cmis:secondary" }, children: [{ type: { id: "type1" } }, { type: { id: "type2" } }] },
+            ],
+          });
+        } else if (url.includes("typeDefinition")) {
+          return Promise.resolve({ data: { propertyDefinitions: {} } });
+        }
+      });
+
+      require("../../../lib/util/index").extractSecondaryTypeIds.mockImplementation((jsonArray, result) => {
+        // Simulate extracting secondary type IDs
+        jsonArray.forEach((item) => {
+          if (item.type && item.type.id) {
+            result.push(item.type.id);
+          }
+        });
+      });
+  
+      // Mock checkMCM to validate secondary properties
+      require("../../../lib/util/index").checkMCM.mockImplementation((responseBody, validSecondaryProperties) => {
+        validSecondaryProperties.push("cmis:name");
+        return true;
+      });
+  
+      await expect(
+        updateAttachment(
+          req,
+          attachment,
+          credentials,
+          token,
+          updatedSecondaryProperties,
+          secondaryPropertiesWithInvalidDefinitions
+        )
+      ).rejects.toThrow("Unsupported properties custom:property");
+  
+      expect(getConfigurations).toHaveBeenCalledTimes(1);
+      expect(axios.get).toHaveBeenCalledTimes(3); // 1 for getSecondaryTypes, 2 for getValidSecondaryProperties
+      expect(require("../../../lib/util/index").checkMCM).toHaveBeenCalledTimes(2);
+    });
+  
+    it("should return 500 if getSecondaryTypes throws an error", async () => {
+      // Mock axios.get to throw an error for getSecondaryTypes
+      axios.get.mockRejectedValue(new Error("Network error"));
+  
+      const result = await updateAttachment(
+        req,
+        attachment,
+        credentials,
+        token,
+        updatedSecondaryProperties,
+        secondaryPropertiesWithInvalidDefinitions
+      );
+  
+      expect(result).toBe(500);
+      expect(getConfigurations).toHaveBeenCalledTimes(1);
+    });
+  
+    it("should throw an error if updateServerRequest fails with a 400 status", async () => {
+      const mockSecondaryTypes = ["type1", "type2"];
+      const mockValidSecondaryProperties = ["cmis:name", "custom:property"];
+      const mockErrorResponse = {
+        response: {
+          status: 400,
+          json: jest.fn().mockResolvedValue({ message: "Bad Request" }),
+        },
+      };
+  
+      // Mock axios.get for getSecondaryTypes and getValidSecondaryProperties
+      axios.get.mockImplementation((url) => {
+        if (url.includes("typeDescendants")) {
+          return Promise.resolve({
+            data: [
+              { type: { id: "cmis:secondary" }, children: [{ type: { id: "type1" } }, { type: { id: "type2" } }] },
+            ],
+          });
+        } else if (url.includes("typeDefinition")) {
+          return Promise.resolve({ data: { propertyDefinitions: {} } });
+        }
+      });
+
+      require("../../../lib/util/index").extractSecondaryTypeIds.mockImplementation((jsonArray, result) => {
+        // Simulate extracting secondary type IDs
+        jsonArray.forEach((item) => {
+          if (item.type && item.type.id) {
+            result.push(item.type.id);
+          }
+        });
+      });
+  
+      // Mock checkMCM to validate secondary properties
+      require("../../../lib/util/index").checkMCM.mockImplementation((responseBody, validSecondaryProperties) => {
+        validSecondaryProperties.push("cmis:name", "custom:property");
+        return true;
+      });
+  
+      // Mock axios.post to throw a 400 error
+      axios.post.mockRejectedValue(mockErrorResponse);
+  
+      await expect(
+        updateAttachment(
+          req,
+          attachment,
+          credentials,
+          token,
+          updatedSecondaryProperties,
+          secondaryPropertiesWithInvalidDefinitions
+        )
+      ).rejects.toThrow("Could not update the attachment");
+  
+      expect(getConfigurations).toHaveBeenCalledTimes(1);
+      expect(axios.get).toHaveBeenCalledTimes(3); // 1 for getSecondaryTypes, 2 for getValidSecondaryProperties
+      expect(require("../../../lib/util/index").checkMCM).toHaveBeenCalledTimes(2);
+      expect(axios.post).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/test/lib/handler/index.test.js
+++ b/test/lib/handler/index.test.js
@@ -1,5 +1,4 @@
 const axios = require("axios");
-const NodeCache = require("node-cache");
 jest.mock("axios");
 jest.mock("node-cache", () => {
   return jest.fn().mockImplementation(() => ({
@@ -535,8 +534,6 @@ describe("handlers", () => {
     });
   
     it("should update attachment successfully and return status code", async () => {
-      const mockSecondaryTypes = ["type1", "type2"];
-      const mockValidSecondaryProperties = ["cmis:namemock", "custom:property"];
       const mockResponse = { status: 200 };
     
       // Mock axios.get for getSecondaryTypes and getValidSecondaryProperties
@@ -593,8 +590,6 @@ describe("handlers", () => {
     });
   
     it("should throw an error if unsupported properties are found", async () => {
-      const mockSecondaryTypes = ["type1", "type2"];
-      const mockValidSecondaryProperties = ["cmis:name"];
   
       // Mock axios.get for getSecondaryTypes and getValidSecondaryProperties
       axios.get.mockImplementation((url) => {
@@ -658,8 +653,6 @@ describe("handlers", () => {
     });
   
     it("should throw an error if updateServerRequest fails with a 400 status", async () => {
-      const mockSecondaryTypes = ["type1", "type2"];
-      const mockValidSecondaryProperties = ["cmis:name", "custom:property"];
       const mockErrorResponse = {
         response: {
           status: 400,

--- a/test/lib/sdm.test.js
+++ b/test/lib/sdm.test.js
@@ -2,12 +2,15 @@ const SDMAttachmentsService = require("../../lib/sdm");
 const NodeCache = require("node-cache");
 const {
   fetchAccessToken,
-  checkAttachmentsToRename,
   getConfigurations,
   isRepositoryVersioned,
   getClientCredentialsToken,
   isRestrictedCharactersInName,
-  getStatusCondition
+  getStatusCondition,
+  getPropertyTitles,
+  getSecondaryPropertiesWithInvalidDefinition,
+  getSecondaryTypeProperties,
+  getUpdatedSecondaryProperties
 } = require("../../lib/util");
 const {
   getDraftAttachments,
@@ -18,7 +21,9 @@ const {
   getURLFromAttachments,
   getFolderIdForEntity,
   updateAttachmentInDraft,
-  setRepositoryId
+  setRepositoryId,
+  getFileNameForAttachmentID,
+  getPropertiesForID
 } = require("../../lib/persistence");
 const {
   deleteAttachmentsOfFolder,
@@ -29,8 +34,8 @@ const {
   createFolder,
   deleteFolderWithAttachments,
   getAttachment,
-  renameAttachment,
-  getRepositoryInfo
+  getRepositoryInfo,
+  updateAttachment
 } = require("../../lib/handler");
 const {
   duplicateDraftFileErr,
@@ -42,7 +47,8 @@ const {
   versionedRepositoryErr,
   nameConstrainErr,
   renameFileErr,
-  renameOtherFilesErr
+  renameOtherFilesErr,
+  sdmRolesErrorMessage
 } = require("../../lib/util/messageConsts");
 
 jest.mock("@cap-js/attachments/lib/basic", () => class {});
@@ -57,7 +63,9 @@ jest.mock("../../lib/persistence", () => ({
   getFolderIdForEntity: jest.fn(),
   updateAttachmentInDraft: jest.fn(),
   getExistingAttachments: jest.fn(),
-  setRepositoryId: jest.fn()
+  setRepositoryId: jest.fn(),
+  getFileNameForAttachmentID: jest.fn(),
+  getPropertiesForID: jest.fn(),
 }));
 jest.mock("../../lib/util", () => ({
   fetchAccessToken: jest.fn(),
@@ -66,7 +74,11 @@ jest.mock("../../lib/util", () => ({
   isRepositoryVersioned: jest.fn(),
   getClientCredentialsToken: jest.fn(),
   isRestrictedCharactersInName: jest.fn(),
-  getStatusCondition: jest.fn()
+  getStatusCondition: jest.fn(),
+  getPropertyTitles: jest.fn(),
+  getSecondaryPropertiesWithInvalidDefinition: jest.fn(),
+  getSecondaryTypeProperties: jest.fn(),
+  getUpdatedSecondaryProperties: jest.fn(),
 }));
 jest.mock("../../lib/handler", () => ({
   deleteAttachmentsOfFolder: jest.fn(),
@@ -78,7 +90,8 @@ jest.mock("../../lib/handler", () => ({
   deleteFolderWithAttachments: jest.fn(),
   getAttachment: jest.fn(),
   renameAttachment: jest.fn(),
-  getRepositoryInfo: jest.fn()
+  getRepositoryInfo: jest.fn(),
+  updateAttachment: jest.fn(),
 }));
 jest.mock("@sap/cds/lib", () => {
   const mockCds = {
@@ -325,6 +338,7 @@ describe("SDMAttachmentsService", () => {
     let token;
   
     beforeEach(() => {
+      jest.resetAllMocks();
       jest.clearAllMocks();
       cds = require("@sap/cds/lib");
       service = new SDMAttachmentsService();
@@ -348,161 +362,947 @@ describe("SDMAttachmentsService", () => {
       token = 'sampleAccessToken';
     });
   
-    it('should rename modified attachments', async () => {
-      service.isFileNameDuplicateInDrafts = jest.fn().mockResolvedValue();
-      service.getAttachementDataInSDM = jest.fn((uri, token, objectId) => {
-        if (objectId === 'url2') {
-          return { filename: 'sampleFileName', folderId: 'sampleFolderId' };
-        }
-        return { filename: 'prevFile1', folderId: 'sampleFolderId' };
-      });
-      service.rename = jest.fn().mockResolvedValue('error occurred');
-  
-      fetchAccessToken.mockResolvedValue(token);
-      getDraftAttachments.mockResolvedValue([
-        { ID: 1, HasActiveEntity: true, filename: 'file1', url: 'url1' },
-        { ID: 2, HasActiveEntity: false, filename: 'fileDraft', url: 'url2' }
-      ]);
-      checkAttachmentsToRename.mockResolvedValue([{ ID: 1, url: 'url1', name: 'file1', prevname: 'prevFile1', folderId: 'sampleFolderId' }]);
-  
-      await service.renameHandler(req);
-  
-      expect(service.isFileNameDuplicateInDrafts).toHaveBeenCalled();
-      expect(fetchAccessToken).toHaveBeenCalledWith(service.creds, 'sampleTokenValue');
-      expect(getDraftAttachments).toHaveBeenCalledWith(cds.model.definitions['sampleTarget.attachments'], req, undefined);
-      expect(service.getAttachementDataInSDM).toHaveBeenCalledWith(service.creds.uri, token, 'url2');
-      expect(checkAttachmentsToRename).toHaveBeenCalled();
-      expect(service.rename).toHaveBeenCalledWith(
-        [{ ID: 1, url: 'url1', name: 'file1', prevname: 'prevFile1', folderId: 'sampleFolderId' },
-        { ID: 2, url: 'url2', name: 'fileDraft', prevname: 'sampleFileName', folderId: 'sampleFolderId' }],
-        token,
-        req
-      );
-      expect(req.warn).toHaveBeenCalledWith(500, 'error occurred');
-    });
-  
     it('should not rename if no attachments are modified', async () => {
       service.isFileNameDuplicateInDrafts = jest.fn().mockResolvedValue();
-      service.getAttachementDataInSDM = jest.fn().mockResolvedValue({ filename: 'fileDraft', folderId: 'folderId' });
-      service.rename = jest.fn();
+      //service.getAttachementDataInSDM = jest.fn().mockResolvedValue({ filename: 'fileDraft', folderId: 'folderId' });
+      service.updateDraftAttachments = jest.fn();
+      service.updateNonDraftAttachments = jest.fn();
   
       fetchAccessToken.mockResolvedValue(token);
       getDraftAttachments.mockResolvedValue([]);
-      checkAttachmentsToRename.mockResolvedValue([]);
   
       await service.renameHandler(req);
   
       expect(service.isFileNameDuplicateInDrafts).not.toHaveBeenCalled();
       expect(fetchAccessToken).not.toHaveBeenCalled();
-      expect(getDraftAttachments).toHaveBeenCalledWith(cds.model.definitions['sampleTarget.attachments'], req, undefined);
-      expect(service.getAttachementDataInSDM).not.toHaveBeenCalled();
-      expect(checkAttachmentsToRename).not.toHaveBeenCalled();
-      expect(service.rename).not.toHaveBeenCalled();
+      expect(getDraftAttachments).toHaveBeenCalledWith(cds.model.definitions['sampleTarget.attachments'], req, 'repo123');
+      expect(service.updateDraftAttachments).not.toHaveBeenCalled();
+      expect(service.updateNonDraftAttachments).not.toHaveBeenCalled();
       expect(req.warn).not.toHaveBeenCalled();
     });
 
-    it('should not modify attachments if filenameInDraft equals filenameInSDM', async () => {
-      service.isFileNameDuplicateInDrafts = jest.fn().mockResolvedValue();
-      service.getAttachementDataInSDM = jest.fn().mockResolvedValue({ filename: 'fileDraft', folderId: 'sampleFolderId' });
-      service.rename = jest.fn().mockResolvedValue('');
-  
-      fetchAccessToken.mockResolvedValue(token);
-      getDraftAttachments.mockResolvedValue([
-        { ID: 1, HasActiveEntity: true, filename: 'file1', url: 'url1' },
-        { ID: 2, HasActiveEntity: false, filename: 'fileDraft', url: 'url2' }
-      ]);
-      checkAttachmentsToRename.mockResolvedValue([]);
-  
-      await service.renameHandler(req);
-  
-      expect(service.isFileNameDuplicateInDrafts).toHaveBeenCalled();
-      expect(fetchAccessToken).toHaveBeenCalledWith(service.creds, 'sampleTokenValue');
-      expect(getDraftAttachments).toHaveBeenCalledWith(cds.model.definitions['sampleTarget.attachments'], req, undefined);
-      expect(service.getAttachementDataInSDM).toHaveBeenCalledWith(service.creds.uri, token, 'url2');
-      expect(checkAttachmentsToRename).toHaveBeenCalled();
-      expect(req.warn).not.toHaveBeenCalled();
-    });
-
-    it('should avoid renaming if there are no modified attachments', async () => {
-      service.isFileNameDuplicateInDrafts = jest.fn().mockResolvedValue();
-      service.getAttachementDataInSDM = jest.fn().mockResolvedValue({ filename: 'fileDraft', folderId: 'sampleFolderId' });
-      service.rename = jest.fn().mockResolvedValue('');
-  
-      fetchAccessToken.mockResolvedValue(token);
-      getDraftAttachments.mockResolvedValue([
-        { ID: 1, HasActiveEntity: true, filename: 'file1', url: 'url1' }
-      ]);
-      checkAttachmentsToRename.mockResolvedValue([]);
-  
-      await service.renameHandler(req);
-  
-      expect(service.isFileNameDuplicateInDrafts).toHaveBeenCalled();
-      expect(fetchAccessToken).toHaveBeenCalledWith(service.creds, 'sampleTokenValue');
-      expect(checkAttachmentsToRename).toHaveBeenCalled();
-      expect(service.rename).not.toHaveBeenCalled();
-      expect(req.warn).not.toHaveBeenCalled();
-    });
-
-    it("should throw correct error message for all rename scenarios in DI", async () => {
-      service.rename = jest.fn().mockResolvedValueOnce([]);
-      const renameSpy = jest.spyOn(service, "rename");
-      getDraftAttachments.mockResolvedValueOnce([
-        {
-          'ID': 'id1',
-          'filename': 'attachment1',
-          'HasActiveEntity' : true
-        },
-        {
-          'ID': 'id2',
-          'filename': 'attachment2',
-          'HasActiveEntity' : true
-        },
-        {
-          'ID': 'id3',
-          'filename': 'attachment3',
-          'HasActiveEntity' : true
-        },
-      ]);
-      const modifiedAttachments = [
-        {
-          ID: 'id1',
-          url: 'url1',
-          name: 'attachment1new',
-          prevname: 'attachment1',
-          folderId: 'folder1'
-        },
-        {
-          ID: 'id2',
-          url: 'url2',
-          name: 'attachment2new',
-          prevname: 'attachment2',
-          folderId: 'folder1'
-        },
-        {
-          ID: 'id3',
-          url: 'url3',
-          name: 'attachment3new',
-          prevname: 'attachment3',
-          folderId: 'folder1'
-        }
+    it('should rename draft and non-draft attachments', async () => {
+      const draftAttachments = [
+        { HasActiveEntity: false, ID: 'draft1' },
+        { HasActiveEntity: false, ID: 'draft2' }
       ];
-      checkAttachmentsToRename.mockResolvedValueOnce(modifiedAttachments);
-      renameAttachment
-        .mockResolvedValueOnce({
-          status: 404,
-          message: "File not found"
-        })
-        .mockResolvedValueOnce({
-          status: 409,
-          message: "File already exists"
-        })
-        .mockResolvedValueOnce({
-          status: 403,
-          message: "Unauthorized"
-        })
+      const nonDraftAttachments = [
+        { HasActiveEntity: true, ID: 'nonDraft1' },
+        { HasActiveEntity: true, ID: 'nonDraft2' }
+      ];
+      const allAttachments = [...draftAttachments, ...nonDraftAttachments];
+  
+      service.isFileNameDuplicateInDrafts = jest.fn().mockResolvedValue();
+      service.updateDraftAttachments = jest.fn().mockResolvedValue([]);
+      service.updateNonDraftAttachments = jest.fn().mockResolvedValue([]);
+      service.clearSecondaryPropertiesCache = jest.fn();
+      service.handleWarning = jest.fn().mockReturnValue([]);
+  
+      fetchAccessToken.mockResolvedValue(token);
+      getDraftAttachments.mockResolvedValue(allAttachments);
+      getPropertyTitles.mockReturnValue(["Title1", "Title2"]);
+      getSecondaryPropertiesWithInvalidDefinition.mockReturnValue({ invalidProperty: "value" });
+      getSecondaryTypeProperties.mockReturnValue(new Map([["property1", "value1"], ["property2", "value2"]]));
+  
       await service.renameHandler(req);
+  
+      expect(service.isFileNameDuplicateInDrafts).toHaveBeenCalledWith(allAttachments, req);
+      expect(fetchAccessToken).toHaveBeenCalledWith(service.creds, 'sampleTokenValue');
+      expect(service.updateDraftAttachments).toHaveBeenCalledTimes(2);
+      expect(service.updateNonDraftAttachments).toHaveBeenCalledTimes(2);
+      expect(service.clearSecondaryPropertiesCache).toHaveBeenCalledWith('repo123');
+      expect(req.warn).not.toHaveBeenCalled();
+    });
 
-      expect(renameSpy).toBeCalled();
+    it('should log warnings if there are errors during renaming', async () => {
+      const draftAttachments = [
+        { HasActiveEntity: false, ID: 'draft1' }
+      ];
+      const nonDraftAttachments = [
+        { HasActiveEntity: true, ID: 'nonDraft1' }
+      ];
+      const allAttachments = [...draftAttachments, ...nonDraftAttachments];
+      const mockErrors = ['Error1', 'Error2'];
+  
+      service.isFileNameDuplicateInDrafts = jest.fn().mockResolvedValue();
+      service.updateDraftAttachments = jest.fn().mockResolvedValue(['Error1']);
+      service.updateNonDraftAttachments = jest.fn().mockResolvedValue(['Error2']);
+      service.clearSecondaryPropertiesCache = jest.fn();
+      service.handleWarning = jest.fn().mockReturnValue(mockErrors);
+  
+      fetchAccessToken.mockResolvedValue(token);
+      getDraftAttachments.mockResolvedValue(allAttachments);
+  
+      await service.renameHandler(req);
+  
+      expect(service.isFileNameDuplicateInDrafts).toHaveBeenCalledWith(allAttachments, req);
+      expect(fetchAccessToken).toHaveBeenCalledWith(service.creds, 'sampleTokenValue');
+      expect(service.updateDraftAttachments).toHaveBeenCalledTimes(1);
+      expect(service.updateNonDraftAttachments).toHaveBeenCalledTimes(1);
+      expect(service.clearSecondaryPropertiesCache).toHaveBeenCalledWith('repo123');
+      expect(req.warn).toHaveBeenCalledWith(500, mockErrors);
+    });
+
+    it('should handle errors during fetchAccessToken', async () => {
+      fetchAccessToken.mockRejectedValue(new Error('Token fetch failed'));
+      getDraftAttachments.mockResolvedValue([{ HasActiveEntity: false, ID: 'draft1' }]);
+      service.isFileNameDuplicateInDrafts = jest.fn();
+      service.updateDraftAttachments = jest.fn();
+      service.updateNonDraftAttachments = jest.fn();
+  
+      await expect(service.renameHandler(req)).rejects.toThrow('Token fetch failed');
+  
+      expect(fetchAccessToken).toHaveBeenCalledWith(service.creds, 'sampleTokenValue');
+      expect(service.isFileNameDuplicateInDrafts).not.toHaveBeenCalled();
+      expect(service.updateDraftAttachments).not.toHaveBeenCalled();
+      expect(service.updateNonDraftAttachments).not.toHaveBeenCalled();
+    });
+
+    it('should handle errors during updateDraftAttachments', async () => {
+      const draftAttachments = [
+        { HasActiveEntity: false, ID: 'draft1' }
+      ];
+      const nonDraftAttachments = [
+        { HasActiveEntity: true, ID: 'nonDraft1' }
+      ];
+      const allAttachments = [...draftAttachments, ...nonDraftAttachments];
+  
+      service.isFileNameDuplicateInDrafts = jest.fn().mockResolvedValue();
+      service.updateDraftAttachments = jest.fn().mockRejectedValue(new Error('Draft update failed'));
+      service.updateNonDraftAttachments = jest.fn().mockResolvedValue([]);
+      service.clearSecondaryPropertiesCache = jest.fn();
+  
+      fetchAccessToken.mockResolvedValue(token);
+      getDraftAttachments.mockResolvedValue(allAttachments);
+  
+      await expect(service.renameHandler(req)).rejects.toThrow('Draft update failed');
+  
+      expect(service.isFileNameDuplicateInDrafts).toHaveBeenCalledWith(allAttachments, req);
+      expect(fetchAccessToken).toHaveBeenCalledWith(service.creds, 'sampleTokenValue');
+      expect(service.updateDraftAttachments).toHaveBeenCalledTimes(1);
+      expect(service.updateNonDraftAttachments).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('updateNonDraftAttachments', () => {
+    let service;
+    let req;
+    let token;
+    let attachment;
+    let attachmentsEntity;
+    let secondaryPropertiesWithInvalidDefinitions;
+    let secondaryTypeProperties;
+  
+    beforeEach(() => {
+      jest.resetAllMocks();
+      jest.clearAllMocks();
+      service = new SDMAttachmentsService();
+      req = {
+        data: {
+          attachments: [{ ID: 'attachment1', filename: 'file1.txt' }]
+        }
+      };
+      token = 'mockToken';
+      attachment = { ID: 'attachment1', filename: 'file1.txt' };
+      attachmentsEntity = {};
+      secondaryPropertiesWithInvalidDefinitions = {};
+      secondaryTypeProperties = new Map();
+  
+      // Mock dependencies
+      service.replacePropertiesInAttachment = jest.fn();
+      getFileNameForAttachmentID.mockResolvedValue('file1.txt');
+      getPropertiesForID.mockResolvedValue({ property1: 'value1' });
+      getUpdatedSecondaryProperties.mockReturnValue({ property1: 'updatedValue1' });
+      updateAttachment.mockResolvedValue(200);
+      isRestrictedCharactersInName.mockReturnValue(false);
+    });
+  
+    it('should return an error if filename contains restricted characters', async () => {
+      isRestrictedCharactersInName.mockReturnValue(true);
+  
+      const result = await service.updateNonDraftAttachments(
+        req,
+        token,
+        attachment,
+        attachmentsEntity,
+        secondaryPropertiesWithInvalidDefinitions,
+        secondaryTypeProperties
+      );
+  
+      expect(result).toEqual([{ typeOfError: 'restricted characters', name: 'file1.txt' }]);
+      expect(service.replacePropertiesInAttachment).toHaveBeenCalledWith(
+        req,
+        'attachment1',
+        'file1.txt',
+        { property1: 'value1' },
+        secondaryTypeProperties
+      );
+    });
+  
+    it('should throw an error if filename is null', async () => {
+      attachment.filename = null;
+  
+      await expect(
+        service.updateNonDraftAttachments(
+          req,
+          token,
+          attachment,
+          attachmentsEntity,
+          secondaryPropertiesWithInvalidDefinitions,
+          secondaryTypeProperties
+        )
+      ).rejects.toThrow('Filename cannot be empty');
+    });
+  
+    it('should update the filename if it differs from the database', async () => {
+      getFileNameForAttachmentID.mockResolvedValue('file2.txt');
+  
+      const result = await service.updateNonDraftAttachments(
+        req,
+        token,
+        attachment,
+        attachmentsEntity,
+        secondaryPropertiesWithInvalidDefinitions,
+        secondaryTypeProperties
+      );
+  
+      expect(getUpdatedSecondaryProperties).toHaveBeenCalledWith(
+        attachment,
+        secondaryTypeProperties,
+        { property1: 'value1' }
+      );
+      expect(updateAttachment).toHaveBeenCalledWith(
+        req,
+        attachment,
+        service.creds,
+        token,
+        { property1: 'updatedValue1', 'cmis:name': 'file1.txt' },
+        secondaryPropertiesWithInvalidDefinitions
+      );
+      expect(result).toEqual([]);
+    });
+
+    it('should update cmis:name if filenameInRequest is not null', async () => {
+      getFileNameForAttachmentID.mockResolvedValue(null);
+      const result = await service.updateNonDraftAttachments(
+        req,
+        token,
+        attachment,
+        attachmentsEntity,
+        secondaryPropertiesWithInvalidDefinitions,
+        secondaryTypeProperties
+      );
+  
+      expect(getUpdatedSecondaryProperties).toHaveBeenCalledWith(
+        attachment,
+        secondaryTypeProperties,
+        { property1: 'value1' }
+      );
+      expect(updateAttachment).toHaveBeenCalledWith(
+        req,
+        attachment,
+        service.creds,
+        token,
+        { property1: 'updatedValue1', 'cmis:name': 'file1.txt' },
+        secondaryPropertiesWithInvalidDefinitions
+      );
+      expect(result).toEqual([]);
+    });
+
+    it('should throw an error if filenameInRequest is null', async () => {
+      getFileNameForAttachmentID.mockResolvedValue(null);
+      attachment.filename = null; // Simulate filenameInRequest being null
+  
+      await expect(
+        service.updateNonDraftAttachments(
+          req,
+          token,
+          attachment,
+          attachmentsEntity,
+          secondaryPropertiesWithInvalidDefinitions,
+          secondaryTypeProperties
+        )
+      ).rejects.toThrow('Filename cannot be empty');
+  
+      expect(updateAttachment).not.toHaveBeenCalled();
+      expect(service.replacePropertiesInAttachment).not.toHaveBeenCalled();
+    });
+  
+    it('should handle a 403 response from updateAttachment', async () => {
+      updateAttachment.mockResolvedValue(403);
+  
+      const result = await service.updateNonDraftAttachments(
+        req,
+        token,
+        attachment,
+        attachmentsEntity,
+        secondaryPropertiesWithInvalidDefinitions,
+        secondaryTypeProperties
+      );
+  
+      expect(result).toEqual([{ typeOfError: 'no sdm roles', name: 'file1.txt' }]);
+      expect(service.replacePropertiesInAttachment).toHaveBeenCalledWith(
+        req,
+        'attachment1',
+        'file1.txt',
+        { property1: 'value1' },
+        secondaryTypeProperties
+      );
+    });
+  
+    it('should handle a 409 response from updateAttachment', async () => {
+      updateAttachment.mockResolvedValue(409);
+  
+      const result = await service.updateNonDraftAttachments(
+        req,
+        token,
+        attachment,
+        attachmentsEntity,
+        secondaryPropertiesWithInvalidDefinitions,
+        secondaryTypeProperties
+      );
+  
+      expect(result).toEqual([{ typeOfError: 'duplicate', name: 'file1.txt' }]);
+      expect(service.replacePropertiesInAttachment).toHaveBeenCalledWith(
+        req,
+        'attachment1',
+        'file1.txt',
+        { property1: 'value1' },
+        secondaryTypeProperties
+      );
+    });
+  
+    it('should handle a 404 response from updateAttachment', async () => {
+      updateAttachment.mockResolvedValue(404);
+  
+      const result = await service.updateNonDraftAttachments(
+        req,
+        token,
+        attachment,
+        attachmentsEntity,
+        secondaryPropertiesWithInvalidDefinitions,
+        secondaryTypeProperties
+      );
+  
+      expect(result).toEqual([{ typeOfError: 'not found', name: 'file1.txt' }]);
+      expect(service.replacePropertiesInAttachment).toHaveBeenCalledWith(
+        req,
+        'attachment1',
+        'file1.txt',
+        { property1: 'value1' },
+        secondaryTypeProperties
+      );
+    });
+
+    it('should handle an unexpected response code in the default case', async () => {
+      // Mock dependencies
+      getFileNameForAttachmentID.mockResolvedValue('file1.txt'); // Simulate fileNameInDB
+      getPropertiesForID.mockResolvedValue({ property1: 'value1' }); // Simulate properties from DB
+      getUpdatedSecondaryProperties.mockReturnValue({ property1: 'updatedValue1' }); // Simulate updated properties
+      updateAttachment.mockResolvedValue(500); // Simulate an unexpected response code
+    
+      // Call the method
+      const result = await service.updateNonDraftAttachments(
+        req,
+        token,
+        attachment,
+        attachmentsEntity,
+        secondaryPropertiesWithInvalidDefinitions,
+        secondaryTypeProperties
+      );
+    
+      // Verify the result contains the error for the unexpected response code
+      expect(result).toEqual([
+        {
+          typeOfError: 'bad request',
+          name: 'file1.txt',
+          message: sdmRolesErrorMessage, // Matches the error message from the default case
+        },
+      ]);
+    
+      // Ensure replacePropertiesInAttachment is called
+      expect(service.replacePropertiesInAttachment).toHaveBeenCalledWith(
+        req,
+        'attachment1',
+        'file1.txt',
+        { property1: 'value1' },
+        secondaryTypeProperties
+      );
+    
+      // Ensure updateAttachment was called with the correct arguments
+      expect(updateAttachment).toHaveBeenCalledWith(
+        req,
+        attachment,
+        service.creds,
+        token,
+        { property1: 'updatedValue1' },
+        secondaryPropertiesWithInvalidDefinitions
+      );
+    });
+  
+    it('should handle unsupported properties error', async () => {
+      updateAttachment.mockRejectedValue(new Error('Unsupported properties: property1, property2'));
+  
+      const result = await service.updateNonDraftAttachments(
+        req,
+        token,
+        attachment,
+        attachmentsEntity,
+        secondaryPropertiesWithInvalidDefinitions,
+        secondaryTypeProperties
+      );
+  
+      expect(result).toEqual([
+        {
+          typeOfError: 'unsupported properties',
+          details: ': property1, property2'
+        }
+      ]);
+      expect(service.replacePropertiesInAttachment).toHaveBeenCalledWith(
+        req,
+        'attachment1',
+        'file1.txt',
+        { property1: 'value1' },
+        secondaryTypeProperties
+      );
+    });
+  
+    it('should handle other errors during updateAttachment', async () => {
+      updateAttachment.mockRejectedValue(new Error('Some other error'));
+  
+      const result = await service.updateNonDraftAttachments(
+        req,
+        token,
+        attachment,
+        attachmentsEntity,
+        secondaryPropertiesWithInvalidDefinitions,
+        secondaryTypeProperties
+      );
+  
+      expect(result).toEqual([
+        {
+          typeOfError: 'bad request',
+          name: 'file1.txt',
+          message: 'Some other error'
+        }
+      ]);
+      expect(service.replacePropertiesInAttachment).toHaveBeenCalledWith(
+        req,
+        'attachment1',
+        'file1.txt',
+        { property1: 'value1' },
+        secondaryTypeProperties
+      );
+    });
+  });
+
+  describe('updateDraftAttachments', () => {
+    let service;
+    let req;
+    let token;
+    let attachment;
+    let attachmentsEntity;
+    let secondaryPropertiesWithInvalidDefinitions;
+    let secondaryTypeProperties;
+  
+    beforeEach(() => {
+      jest.resetAllMocks();
+      jest.clearAllMocks();
+      service = new SDMAttachmentsService();
+      req = {
+        reject: jest.fn(),
+        data: {
+          attachments: [{ ID: 'attachment1', filename: 'file1.txt' }]
+        }
+      };
+      token = 'mockToken';
+      attachment = { ID: 'attachment1', filename: 'file1.txt', url: 'mockUrl' };
+      attachmentsEntity = {};
+      secondaryPropertiesWithInvalidDefinitions = {};
+      secondaryTypeProperties = new Map();
+
+      // Initialize creds with a valid uri
+      service.creds = { uri: 'mockUri' };
+  
+      // Mock dependencies
+      service.replacePropertiesInAttachment = jest.fn();
+      service.getAttachementDataInSDM = jest.fn().mockResolvedValue({ filename: 'file1.txt', folderId: 'mockFolderId' });
+      getPropertiesForID.mockResolvedValue({ property1: 'value1' });
+      getUpdatedSecondaryProperties.mockReturnValue({ property1: 'updatedValue1' });
+      updateAttachment.mockResolvedValue(200);
+      isRestrictedCharactersInName.mockReturnValue(false);
+    });
+  
+    it('should return an error if filename contains restricted characters', async () => {
+      isRestrictedCharactersInName.mockReturnValue(true);
+  
+      const result = await service.updateDraftAttachments(
+        req,
+        token,
+        attachment,
+        attachmentsEntity,
+        secondaryPropertiesWithInvalidDefinitions,
+        secondaryTypeProperties
+      );
+  
+      expect(result).toEqual([{ typeOfError: 'restricted characters', filenameInRequest: 'file1.txt' }]);
+      expect(service.replacePropertiesInAttachment).toHaveBeenCalledWith(
+        req,
+        'attachment1',
+        'file1.txt',
+        { property1: 'value1' },
+        secondaryTypeProperties
+      );
+    });
+  
+    it('should reject if filenameInRequest is null', async () => {
+      attachment.filename = null;
+  
+      await service.updateDraftAttachments(
+        req,
+        token,
+        attachment,
+        attachmentsEntity,
+        secondaryPropertiesWithInvalidDefinitions,
+        secondaryTypeProperties
+      );
+  
+      expect(req.reject).toHaveBeenCalledWith(400, 'Filename cannot be empty');
+    });
+  
+    it('should update cmis:name if filenameInRequest differs from filenameInSDM', async () => {
+      service.getAttachementDataInSDM.mockResolvedValue({ filename: 'file2.txt', folderId: 'mockFolderId' });
+  
+      const result = await service.updateDraftAttachments(
+        req,
+        token,
+        attachment,
+        attachmentsEntity,
+        secondaryPropertiesWithInvalidDefinitions,
+        secondaryTypeProperties
+      );
+  
+      expect(getUpdatedSecondaryProperties).toHaveBeenCalledWith(
+        attachment,
+        secondaryTypeProperties,
+        { property1: 'value1' }
+      );
+      expect(updateAttachment).toHaveBeenCalledWith(
+        req,
+        attachment,
+        service.creds,
+        token,
+        { property1: 'updatedValue1', 'cmis:name': 'file1.txt' },
+        secondaryPropertiesWithInvalidDefinitions
+      );
+      expect(result).toEqual([]);
+    });
+  
+    it('should handle a 403 response from updateAttachment', async () => {
+      updateAttachment.mockResolvedValue(403);
+  
+      const result = await service.updateDraftAttachments(
+        req,
+        token,
+        attachment,
+        attachmentsEntity,
+        secondaryPropertiesWithInvalidDefinitions,
+        secondaryTypeProperties
+      );
+  
+      expect(result).toEqual([{ typeOfError: 'no sdm roles', name: 'file1.txt' }]);
+      expect(service.replacePropertiesInAttachment).toHaveBeenCalledWith(
+        req,
+        'attachment1',
+        'file1.txt',
+        { property1: 'value1' },
+        secondaryTypeProperties
+      );
+    });
+  
+    it('should handle a 409 response from updateAttachment', async () => {
+      updateAttachment.mockResolvedValue(409);
+  
+      const result = await service.updateDraftAttachments(
+        req,
+        token,
+        attachment,
+        attachmentsEntity,
+        secondaryPropertiesWithInvalidDefinitions,
+        secondaryTypeProperties
+      );
+  
+      expect(result).toEqual([{ typeOfError: 'duplicate', name: 'file1.txt' }]);
+      expect(service.replacePropertiesInAttachment).toHaveBeenCalledWith(
+        req,
+        'attachment1',
+        'file1.txt',
+        { property1: 'value1' },
+        secondaryTypeProperties
+      );
+    });
+  
+    it('should handle a 404 response from updateAttachment', async () => {
+      updateAttachment.mockResolvedValue(404);
+  
+      const result = await service.updateDraftAttachments(
+        req,
+        token,
+        attachment,
+        attachmentsEntity,
+        secondaryPropertiesWithInvalidDefinitions,
+        secondaryTypeProperties
+      );
+  
+      expect(result).toEqual([{ typeOfError: 'not found', name: 'file1.txt' }]);
+      expect(service.replacePropertiesInAttachment).toHaveBeenCalledWith(
+        req,
+        'attachment1',
+        'file1.txt',
+        { property1: 'value1' },
+        secondaryTypeProperties
+      );
+    });
+
+    it('should handle an unexpected response code in the default case', async () => {
+      // Mock dependencies
+      service.getAttachementDataInSDM.mockResolvedValue({ filename: 'file1.txt', folderId: 'mockFolderId' });
+      getPropertiesForID.mockResolvedValue({ property1: 'value1' });
+      getUpdatedSecondaryProperties.mockReturnValue({ property1: 'updatedValue1' });
+      updateAttachment.mockResolvedValue(500); // Simulate an unexpected response code
+    
+      // Call the method
+      const result = await service.updateDraftAttachments(
+        req,
+        token,
+        attachment,
+        attachmentsEntity,
+        secondaryPropertiesWithInvalidDefinitions,
+        secondaryTypeProperties
+      );
+    
+      // Verify the result contains the error for the unexpected response code
+      expect(result).toEqual([
+        {
+          typeOfError: 'bad request',
+          name: 'file1.txt',
+          message: sdmRolesErrorMessage, // Matches the error message from the default case
+        },
+      ]);
+    
+      // Ensure replacePropertiesInAttachment is called
+      expect(service.replacePropertiesInAttachment).toHaveBeenCalledWith(
+        req,
+        'attachment1',
+        'file1.txt',
+        { property1: 'value1' },
+        secondaryTypeProperties
+      );
+    
+      // Ensure updateAttachment was called with the correct arguments
+      expect(updateAttachment).toHaveBeenCalledWith(
+        req,
+        attachment,
+        service.creds,
+        token,
+        { property1: 'updatedValue1' },
+        secondaryPropertiesWithInvalidDefinitions
+      );
+    });
+  
+    it('should handle unsupported properties error', async () => {
+      updateAttachment.mockRejectedValue(new Error('Unsupported properties: property1, property2'));
+  
+      const result = await service.updateDraftAttachments(
+        req,
+        token,
+        attachment,
+        attachmentsEntity,
+        secondaryPropertiesWithInvalidDefinitions,
+        secondaryTypeProperties
+      );
+  
+      expect(result).toEqual([
+        {
+          typeOfError: 'unsupported properties',
+          details: ': property1, property2'
+        }
+      ]);
+      expect(service.replacePropertiesInAttachment).toHaveBeenCalledWith(
+        req,
+        'attachment1',
+        'file1.txt',
+        { property1: 'value1' },
+        secondaryTypeProperties
+      );
+    });
+  
+    it('should handle other errors during updateAttachment', async () => {
+      updateAttachment.mockRejectedValue(new Error('Some other error'));
+  
+      const result = await service.updateDraftAttachments(
+        req,
+        token,
+        attachment,
+        attachmentsEntity,
+        secondaryPropertiesWithInvalidDefinitions,
+        secondaryTypeProperties
+      );
+  
+      expect(result).toEqual([
+        {
+          typeOfError: 'bad request',
+          name: 'file1.txt',
+          message: 'Some other error'
+        }
+      ]);
+      expect(service.replacePropertiesInAttachment).toHaveBeenCalledWith(
+        req,
+        'attachment1',
+        'file1.txt',
+        { property1: 'value1' },
+        secondaryTypeProperties
+      );
+    });
+  });
+
+  describe('replacePropertiesInAttachment', () => {
+    let service;
+    let req;
+    let secondaryTypeProperties;
+  
+    beforeEach(() => {
+      jest.clearAllMocks();
+      service = new SDMAttachmentsService();
+      req = {
+        data: {
+          attachments: [
+            { ID: 'attachment1', filename: 'oldFileName', property1: 'oldValue1', property2: 'oldValue2' },
+            { ID: 'attachment2', filename: 'anotherOldFileName', property3: 'oldValue3' }
+          ]
+        }
+      };
+      secondaryTypeProperties = new Map([
+        ['secondaryKey1', 'property1'],
+        ['secondaryKey2', 'property2']
+      ]);
+    });
+  
+    it('should replace properties and filename in the attachment', () => {
+      const propertiesInDB = { property1: 'newValue1', property2: 'newValue2' };
+      const fileName = 'newFileName';
+  
+      service.replacePropertiesInAttachment(req, 'attachment1', fileName, propertiesInDB, secondaryTypeProperties);
+  
+      const updatedAttachment = req.data.attachments.find(att => att.ID === 'attachment1');
+      expect(updatedAttachment.filename).toBe('newFileName');
+      expect(updatedAttachment.secondaryKey1).toBe('newValue1');
+      expect(updatedAttachment.secondaryKey2).toBe('newValue2');
+    });
+  
+    it('should not modify properties if propertiesInDB is null', () => {
+      const fileName = 'newFileName';
+  
+      service.replacePropertiesInAttachment(req, 'attachment1', fileName, null, secondaryTypeProperties);
+  
+      const updatedAttachment = req.data.attachments.find(att => att.ID === 'attachment1');
+      expect(updatedAttachment.filename).toBe('newFileName');
+      expect(updatedAttachment.property1).toBe('oldValue1'); // Ensure properties are not modified
+      expect(updatedAttachment.property2).toBe('oldValue2');
+    });
+  
+    it('should not modify attachments if ID is not found', () => {
+      const propertiesInDB = { property1: 'newValue1', property2: 'newValue2' };
+      const fileName = 'newFileName';
+  
+      service.replacePropertiesInAttachment(req, 'nonExistentID', fileName, propertiesInDB, secondaryTypeProperties);
+  
+      const updatedAttachment = req.data.attachments.find(att => att.ID === 'attachment1');
+      expect(updatedAttachment.filename).toBe('oldFileName'); // Ensure filename is not modified
+      expect(updatedAttachment.property1).toBe('oldValue1'); // Ensure properties are not modified
+      expect(updatedAttachment.property2).toBe('oldValue2');
+    });
+  
+    it('should handle secondaryTypeProperties with no matching keys', () => {
+      const propertiesInDB = { property3: 'newValue3' }; // No matching keys in secondaryTypeProperties
+      const fileName = 'newFileName';
+  
+      service.replacePropertiesInAttachment(req, 'attachment1', fileName, propertiesInDB, secondaryTypeProperties);
+  
+      const updatedAttachment = req.data.attachments.find(att => att.ID === 'attachment1');
+      expect(updatedAttachment.filename).toBe('newFileName');
+      expect(updatedAttachment.property1).toBe('oldValue1'); // Ensure properties are not modified
+      expect(updatedAttachment.property2).toBe('oldValue2');
+    });
+  
+    it('should replace only matching properties in the attachment', () => {
+      const propertiesInDB = { property1: 'newValue1' }; // Only one matching property
+      const fileName = 'newFileName';
+  
+      service.replacePropertiesInAttachment(req, 'attachment1', fileName, propertiesInDB, secondaryTypeProperties);
+  
+      const updatedAttachment = req.data.attachments.find(att => att.ID === 'attachment1');
+      expect(updatedAttachment.filename).toBe('newFileName');
+      expect(updatedAttachment.secondaryKey1).toBe('newValue1'); // Ensure matching property is updated
+      expect(updatedAttachment.secondaryKey2).toBeUndefined(); // Ensure non-matching property is not updated
+    });
+  });
+
+  // describe('clearSecondaryPropertiesCache', () => {
+  //   let service;
+  //   let cache;
+  //   const repositoryId = 'mockRepositoryId';
+  //   const cacheKey = `validSecondaryProperties_${repositoryId}`;
+  
+  //   beforeEach(() => {
+  //     jest.clearAllMocks();
+  
+  //     // Mock the global cache object
+  //     cache = {
+  //       has: jest.fn(),
+  //       del: jest.fn(),
+  //     };
+  //     global.cache = cache; // Assign the mocked cache to the global object
+  
+  //     service = new SDMAttachmentsService();
+  //   });
+  
+  //   afterEach(() => {
+  //     delete global.cache; // Clean up the global cache mock
+  //   });
+  
+  //   it('should remove the cache key if it exists', () => {
+  //     // Mock the cache to have the key
+  //     cache.has.mockReturnValue(true);
+  
+  //     // Call the method
+  //     service.clearSecondaryPropertiesCache(repositoryId);
+  
+  //     // Verify the cache key is removed
+  //     expect(cache.has).toHaveBeenCalledWith(cacheKey);
+  //     expect(cache.del).toHaveBeenCalledWith(cacheKey);
+  //   });
+  
+  //   it('should do nothing if the cache key does not exist', () => {
+  //     // Mock the cache to not have the key
+  //     cache.has.mockReturnValue(false);
+  
+  //     // Call the method
+  //     service.clearSecondaryPropertiesCache(repositoryId);
+  
+  //     // Verify the cache key is not removed
+  //     expect(cache.has).toHaveBeenCalledWith(cacheKey);
+  //     expect(cache.del).not.toHaveBeenCalled();
+  //   });
+  // });
+
+  describe('handleWarning', () => {
+    let service;
+    let propertyTitles;
+  
+    beforeEach(() => {
+      jest.clearAllMocks();
+      service = new SDMAttachmentsService();
+      propertyTitles = {
+        property1: 'Invalid Property 1',
+        property2: 'Invalid Property 2',
+      };
+    });
+  
+    it('should handle restricted characters errors', () => {
+      const allErrors = [
+        { typeOfError: 'restricted characters', name: 'file1.txt' },
+        { typeOfError: 'restricted characters', name: 'file2.txt' },
+      ];
+  
+      const result = service.handleWarning(allErrors, propertyTitles);
+  
+      expect(result).toContain('file1.txt');
+      expect(result).toContain('file2.txt');
+      expect(result).toContain('Update');
+    });
+  
+    it('should handle duplicate errors', () => {
+      const allErrors = [
+        { typeOfError: 'duplicate', name: 'file1.txt' },
+        { typeOfError: 'duplicate', name: 'file2.txt' },
+      ];
+      getStatusCondition.mockReturnValue('already');
+  
+      const result = service.handleWarning(allErrors, propertyTitles);
+  
+      expect(result).toContain('file1.txt');
+      expect(result).toContain('file2.txt');
+      expect(result).toContain('already');
+    });
+  
+    it('should handle not found errors', () => {
+      const allErrors = [
+        { typeOfError: 'not found', name: 'file1.txt' },
+        { typeOfError: 'not found', name: 'file2.txt' },
+      ];
+      getStatusCondition.mockReturnValue("don't");
+  
+      const result = service.handleWarning(allErrors, propertyTitles);
+  
+      expect(result).toContain('file1.txt');
+      expect(result).toContain('file2.txt');
+      expect(result).toContain("don't");
+    });
+  
+    it('should handle no SDM roles errors', () => {
+      const allErrors = [
+        { typeOfError: 'no sdm roles', name: 'file1.txt' },
+        { typeOfError: 'no sdm roles', name: 'file2.txt' },
+      ];
+  
+      const result = service.handleWarning(allErrors, propertyTitles);
+  
+      expect(result).toContain('file1.txt');
+      expect(result).toContain('file2.txt');
+      expect(result).toContain('update');
+    });
+  
+    it('should handle unsupported properties errors', () => {
+      const allErrors = [
+        { typeOfError: 'unsupported properties', details: 'property1, property2' },
+      ];
+  
+      const result = service.handleWarning(allErrors, propertyTitles);
+  
+      expect(result).toContain('Invalid Property 1');
+      expect(result).toContain('Invalid Property 2');
+    });
+  
+    it('should handle bad request errors', () => {
+      const allErrors = [
+        { typeOfError: 'bad request', name: 'file1.txt', message: 'Some error' },
+      ];
+  
+      const result = service.handleWarning(allErrors, propertyTitles);
+  
+      expect(result).toContain('file1.txt');
+      expect(result).toContain('Some error');
+    });
+  
+    it('should handle other errors', () => {
+      const allErrors = [
+        { typeOfError: 'other error', name: 'file1.txt' },
+        { typeOfError: 'other error', name: 'file2.txt' },
+      ];
+  
+      const result = service.handleWarning(allErrors, propertyTitles);
+  
+      expect(result).toContain('file1.txt');
+      expect(result).toContain('file2.txt');
+    });
+  
+    it('should return an empty string if there are no errors', () => {
+      const allErrors = [];
+  
+      const result = service.handleWarning(allErrors, propertyTitles);
+  
+      expect(result).toBe('');
     });
   });
 
@@ -1253,169 +2053,6 @@ describe("SDMAttachmentsService", () => {
     })
   });
 
-  describe("rename", () => {
-    let service;
-    let mockReq;
-    let cds;
-    beforeEach(() => {
-      NodeCache.prototype.get.mockClear();
-      jest.clearAllMocks();
-      cds = require("@sap/cds/lib");
-      service = new SDMAttachmentsService();
-      service.creds = { uaa: "mocked uaa" };
-      mockReq = {
-        query: {
-          target: {
-            name: "testName",
-          },
-        },
-        user: {
-          tokenInfo: {
-            getTokenValue: jest.fn().mockReturnValue("mocked_token"),
-          },
-        },
-        reject: jest.fn(),
-        info: jest.fn(),
-        warn: jest.fn()
-      };
-
-      cds.model.definitions[mockReq.query.target.name + ".attachments"] = {
-        keys: {
-          up_: {
-            keys: [{ ref: ["attachment"] }],
-          },
-        },
-      };
-      const repoInfo = {
-        data: {
-          "123": {
-            capabilities: {
-              "capabilityContentStreamUpdatability": "pwconly"
-            }
-          }
-        }
-      }
-      NodeCache.prototype.get.mockImplementation(() => undefined);
-      getConfigurations.mockResolvedValueOnce({repositoryId: "123"});
-      getRepositoryInfo.mockResolvedValueOnce(repoInfo);
-      isRepositoryVersioned.mockResolvedValueOnce(false);
-    });
-
-    it("should call onRename without any issue", async () => {
-      const token = "token";
-      const modifiedAttachments = [];
-
-      service.onRename = jest.fn().mockResolvedValueOnce([]);
-      const onRenameSpy = jest.spyOn(service, "onRename");
-
-      await service.rename(
-        modifiedAttachments,
-        token,
-        mockReq
-      );
-      
-      expect(onRenameSpy).toBeCalled();
-      expect(mockReq.info).not.toBeCalled();
-    })
-
-    it("should handle failure in onRename with duplicate error", async () => {
-      const token = "token";
-      const modifiedAttachments = [];
-      
-      getStatusCondition.mockReturnValueOnce("already");
-      service.onRename = jest.fn().mockResolvedValue([{typeOfError:'duplicate',name:"renameduplicate"}]);
-
-      response = await service.rename(
-        modifiedAttachments,
-        token,
-        mockReq
-      );
-
-      expect(response).toBe(renameFileErr(["renameduplicate"], "already"));
-    })
-
-    it("should handle failure in onRename with not found error", async () => {
-      const token = "token";
-      const modifiedAttachments = [];
-  
-      getStatusCondition.mockReturnValueOnce("don't");
-      service.onRename = jest.fn().mockResolvedValue([{typeOfError:'not found',name:"renameNotFound"}]);
-  
-      const response = await service.rename(
-        modifiedAttachments,
-        token,
-        mockReq
-      );
-  
-      expect(response).toBe(renameFileErr(["renameNotFound"], "don't"));
-    });
-  
-    it("should handle failure in onRename with restricted characters error", async () => {
-      const token = "token";
-      const modifiedAttachments = [];
-  
-      service.onRename = jest.fn().mockResolvedValue([{typeOfError:'restricted characters',name:"renameRestricted"}]);
-  
-      const response = await service.rename(
-        modifiedAttachments,
-        token,
-        mockReq
-      );
-  
-      expect(response).toBe(nameConstrainErr(["renameRestricted"], "Rename"));
-    });
-  
-    it("should handle failure in onRename with other errors", async () => {
-      const token = "token";
-      const modifiedAttachments = [];
-  
-      service.onRename = jest.fn().mockResolvedValue([{typeOfError:'some other error',name:"renameOtherError"}]);
-  
-      const response = await service.rename(
-        modifiedAttachments,
-        token,
-        mockReq
-      );
-  
-      expect(response).toBe(renameOtherFilesErr(["renameOtherError"],["some other error"]));
-    });
-
-    it("should handle multiple errors in onRename", async () => {
-      const token = "token";
-      const modifiedAttachments = [];
-  
-      // Provide behavior specific to this test
-      getStatusCondition.mockImplementation((statusCode) => {
-        if (statusCode === 404) {
-          return "don't";
-        } else if (statusCode === 409) {
-          return "already";
-        }
-      });
-  
-      service.onRename = jest.fn().mockResolvedValue([
-        { typeOfError: 'duplicate', name: "renameduplicate" },
-        { typeOfError: 'not found', name: "renameNotFound" },
-        { typeOfError: 'restricted characters', name: "renameRestricted" },
-        { typeOfError: 'some other error', name: "renameOtherError" }
-      ]);
-  
-      const response = await service.rename(
-        modifiedAttachments,
-        token,
-        mockReq
-      );
-  
-      const expectedResponse = 
-        nameConstrainErr(["renameRestricted"], "Rename") +
-        renameFileErr(["renameduplicate"], "already") +
-        renameFileErr(["renameNotFound"], "don't") +
-        renameOtherFilesErr(["renameOtherError"], ["some other error"]);
-  
-      expect(response).toBe(expectedResponse);
-    });
-  });
-
   describe('onCreate', () => {
     let data, credentials, token, req, parentId, service;
   
@@ -1481,146 +2118,6 @@ describe("SDMAttachmentsService", () => {
       await service.onCreate(data, credentials, token, req, parentId);
   
       expect(req.reject).toHaveBeenCalledWith(otherFileErr(['file1']));
-    });
-  });
-
-  describe("onRename", () => {
-    let service;
-    beforeEach(() => {
-      jest.clearAllMocks();
-      jest.resetAllMocks();
-      service = new SDMAttachmentsService();
-      service.creds = { uri: 'sampleUri' };
-    });
-    it("should return empty array if no attachments fail", async () => {
-      const modifiedAttachments = [{ name: "name", ID: "someID", url: "someURL" }];
-      const credentials = {};
-      const token = "token";
-      const req = {
-        data: {
-          attachments: [
-            {
-              ID: 'someID',
-              filename: 'someFilename'
-            }
-          ]
-        }
-      };
-  
-      isRestrictedCharactersInName.mockReturnValue(false);
-      renameAttachment.mockResolvedValueOnce({
-        status: 200,
-        data: {
-          message: 'success'
-        }
-      })
-      service.getAttachementDataInSDM = jest.fn().mockResolvedValue({ filename: 'someFilename' });
-  
-      const result = await service.onRename(
-        modifiedAttachments,
-        credentials,
-        token,
-        req
-      );
-      expect(result).toEqual([]);
-    });
-
-    it("should return an error if name is empty", async () => {
-      const modifiedAttachments = [{ name: "" }];
-      const credentials = {};
-      const token = "token";
-    
-      await expect(service.onRename(modifiedAttachments, credentials, token))
-        .rejects
-        .toThrow("Filename cannot be empty");
-    
-      expect(renameAttachment).toHaveBeenCalledTimes(0);
-    });
-
-    it("should return failed request messages if rename fails for some attachments", async () => {
-      const modifiedAttachments = [{ name: "attachment#1", id:"id1" }, { name: "attachment#2", id:"id2", prevname: "attachment#2prev" }, { name: "attachment#3", id:"id3" }, { name: "attachment#4", id:"id4" }];
-      const credentials = {};
-      const token = "token";
-      const req = {
-        data: {
-          attachments: [
-            {
-              id: "id1",
-              name: "attachment#1"
-            },
-            {
-              id: "id2",
-              name: "attachment#2",
-              prevname: "attachment#2prev"
-            },
-            {
-              id: "id3",
-              name: "attachment#3"
-            },
-            {
-              id: "id4",
-              name: "attachment#4"
-            }
-          ]
-        }
-      }
-    
-      isRestrictedCharactersInName.mockReturnValue(false);
-      renameAttachment
-        .mockResolvedValueOnce({
-          status: 200,
-          data: { succinctProperties: { "cmis:objectId": "url" } },
-        })
-        .mockResolvedValueOnce({
-          status: 404,
-          message: "File not found"
-        })
-        .mockResolvedValueOnce({
-          status: 409,
-          message: "File already exists"
-        })
-        .mockResolvedValueOnce({
-          status: 403,
-          message: "Unauthorized"
-        })
-
-      const result = await service.onRename(
-        modifiedAttachments,
-        credentials,
-        token,
-        req
-      );
-      expect(result).toEqual([{ "name": "attachment#2prev", "typeOfError": "not found" },{ "name": "attachment#3", "typeOfError": "duplicate" },{ "name": "attachment#4", "typeOfError": "Unauthorized" }]);
-    });
-
-    it("should handle restricted characters in filename and update filename in request", async () => {
-      const modifiedAttachments = [{ name: "invalid/name", ID: "someID", url: "someURL" }];
-      const credentials = {};
-      const token = "token";
-      const req = {
-        data: {
-          attachments: [
-            {
-              ID: 'someID',
-              filename: 'someFilename'
-            }
-          ]
-        }
-      };
-  
-      isRestrictedCharactersInName.mockReturnValue(true);
-      service.getAttachementDataInSDM = jest.fn().mockResolvedValue({ filename: 'updatedFilename' });
-  
-      const result = await service.onRename(
-        modifiedAttachments,
-        credentials,
-        token,
-        req
-      );
-  
-      expect(result).toEqual([{ typeOfError: 'restricted characters', name: 'invalid/name' }]);
-      expect(service.getAttachementDataInSDM).toHaveBeenCalledWith('sampleUri', token, 'someURL');
-      expect(req.data.attachments[0].filename).toBe('updatedFilename');
     });
   });
 

--- a/test/lib/sdm.test.js
+++ b/test/lib/sdm.test.js
@@ -46,8 +46,6 @@ const {
   userDoesNotHaveRequiredScope,
   versionedRepositoryErr,
   nameConstrainErr,
-  renameFileErr,
-  renameOtherFilesErr,
   sdmRolesErrorMessage
 } = require("../../lib/util/messageConsts");
 
@@ -498,6 +496,7 @@ describe("SDMAttachmentsService", () => {
       jest.clearAllMocks();
       service = new SDMAttachmentsService();
       req = {
+        reject: jest.fn(),
         data: {
           attachments: [{ ID: 'attachment1', filename: 'file1.txt' }]
         }
@@ -539,19 +538,20 @@ describe("SDMAttachmentsService", () => {
       );
     });
   
-    it('should throw an error if filename is null', async () => {
+    it('should call req.reject if filename is null', async () => {
       attachment.filename = null;
-  
-      await expect(
-        service.updateNonDraftAttachments(
-          req,
-          token,
-          attachment,
-          attachmentsEntity,
-          secondaryPropertiesWithInvalidDefinitions,
-          secondaryTypeProperties
-        )
-      ).rejects.toThrow('Filename cannot be empty');
+    
+      await service.updateNonDraftAttachments(
+        req,
+        token,
+        attachment,
+        attachmentsEntity,
+        secondaryPropertiesWithInvalidDefinitions,
+        secondaryTypeProperties
+      );
+    
+      // Verify that req.reject was called with the correct arguments
+      expect(req.reject).toHaveBeenCalledWith(400, 'Filename cannot be empty');
     });
   
     it('should update the filename if it differs from the database', async () => {
@@ -607,25 +607,6 @@ describe("SDMAttachmentsService", () => {
         secondaryPropertiesWithInvalidDefinitions
       );
       expect(result).toEqual([]);
-    });
-
-    it('should throw an error if filenameInRequest is null', async () => {
-      getFileNameForAttachmentID.mockResolvedValue(null);
-      attachment.filename = null; // Simulate filenameInRequest being null
-  
-      await expect(
-        service.updateNonDraftAttachments(
-          req,
-          token,
-          attachment,
-          attachmentsEntity,
-          secondaryPropertiesWithInvalidDefinitions,
-          secondaryTypeProperties
-        )
-      ).rejects.toThrow('Filename cannot be empty');
-  
-      expect(updateAttachment).not.toHaveBeenCalled();
-      expect(service.replacePropertiesInAttachment).not.toHaveBeenCalled();
     });
   
     it('should handle a 403 response from updateAttachment', async () => {
@@ -845,7 +826,7 @@ describe("SDMAttachmentsService", () => {
         secondaryTypeProperties
       );
   
-      expect(result).toEqual([{ typeOfError: 'restricted characters', filenameInRequest: 'file1.txt' }]);
+      expect(result).toEqual([{ typeOfError: 'restricted characters', name: 'file1.txt' }]);
       expect(service.replacePropertiesInAttachment).toHaveBeenCalledWith(
         req,
         'attachment1',

--- a/test/lib/util/index.test.js
+++ b/test/lib/util/index.test.js
@@ -19,7 +19,6 @@ const {
 } = require("../../../lib/util/index");
 
 const cds = require("@sap/cds");
-const { getExistingAttachments } = require("../../../lib/persistence");
 const { sdmAnnotationAdditionalproperty, sdmAnnotationAdditionalpropertyName } = require("../../../lib/util/messageConsts");
 
 jest.mock("../../../lib/persistence", () => ({

--- a/test/lib/util/index.test.js
+++ b/test/lib/util/index.test.js
@@ -5,15 +5,22 @@ const jwt = require('jsonwebtoken');
 const {
   fetchAccessToken,
   getConfigurations,
-  checkAttachmentsToRename,
   isRepositoryVersioned,
   getClientCredentialsToken,
   isRestrictedCharactersInName,
   getStatusCondition,
+  getPropertyTitles,
+  getSecondaryPropertiesWithInvalidDefinition,
+  getSecondaryTypeProperties,
+  getUpdatedSecondaryProperties,
+  extractSecondaryTypeIds,
+  checkMCM,
+  prepareSecondaryProperties
 } = require("../../../lib/util/index");
 
 const cds = require("@sap/cds");
 const { getExistingAttachments } = require("../../../lib/persistence");
+const { sdmAnnotationAdditionalproperty, sdmAnnotationAdditionalpropertyName } = require("../../../lib/util/messageConsts");
 
 jest.mock("../../../lib/persistence", () => ({
   getExistingAttachments: jest.fn(),
@@ -360,51 +367,6 @@ describe("util", () => {
         });
   });
 
-  describe("checkAttachmentsToRename", () => {
-    it("should do nothing if attachment_val_rename is empty", async () => {
-      let attachment_val_rename = [];
-      let attachmentIDs = [];
-      let attachments = [];
-      await checkAttachmentsToRename(attachment_val_rename, attachmentIDs, attachments)
-      expect(getExistingAttachments).not.toBeCalled();
-    });
-
-    it("should call getExistingAttachments if attachment_val_rename is not empty", async () => {
-      let attachment_val_rename = [
-        {
-          ID: 1,
-          filename: "name1",
-          url: "url1",
-        },
-        {
-          ID: 2,
-          filename: "name2",
-          url: "url2",
-        },
-      ];
-      let attachmentIDs = ["1", "2"];
-      let attachments = ["attachments1", "attachments2"];
-      const existingAttachments = [
-        {
-          ID: 1,
-          filename: "Old_File.pdf",
-          folderId: "folder1",
-        },
-        {
-          ID: 2,
-          filename: "Another_Old_File.pdf",
-          folderId: "folder2",
-        },
-      ];      
-
-      getExistingAttachments.mockResolvedValueOnce(existingAttachments);
-
-      await checkAttachmentsToRename(attachment_val_rename, attachmentIDs, attachments)
-
-      expect(getExistingAttachments).toBeCalled();
-    });
-  });
-
   describe("isRestrictedCharactersInName", () => {
     it("should return true if the filename contains a forward slash", () => {
       const filename = "file/name";
@@ -451,6 +413,599 @@ describe("util", () => {
     it('should return undefined for unknown status code', () => {
       const result = getStatusCondition(500); // Example of a status that isn't handled specifically
       expect(result).toBeUndefined();
+    });
+  });
+
+  describe("getPropertyTitles", () => {
+    it("should return an empty map if attachmentEntity is null", () => {
+      const attachmentEntity = null;
+      const attachment = { key1: "value1" };
+  
+      const result = getPropertyTitles(attachmentEntity, attachment);
+  
+      expect(result).toEqual({});
+    });
+  
+    it("should return a map with property names and titles when annotations are present", () => {
+      const attachmentEntity = {
+        elements: {
+          key1: {
+            [sdmAnnotationAdditionalpropertyName]: "property1",
+            "@title": "Title 1",
+            name: "key1",
+          },
+          key2: {
+            [sdmAnnotationAdditionalpropertyName]: "property2",
+            "@title": "Title 2",
+            name: "key2",
+          },
+        },
+      };
+      const attachment = { key1: "value1", key2: "value2" };
+  
+      const result = getPropertyTitles(attachmentEntity, attachment);
+  
+      expect(result).toEqual({
+        property1: "Title 1",
+        property2: "Title 2",
+      });
+    });
+  
+    it("should fallback to element name if @title annotation is not present", () => {
+      const attachmentEntity = {
+        elements: {
+          key1: {
+            [sdmAnnotationAdditionalpropertyName]: "property1",
+            name: "key1",
+          },
+          key2: {
+            [sdmAnnotationAdditionalpropertyName]: "property2",
+            "@title": "Title 2",
+            name: "key2",
+          },
+        },
+      };
+      const attachment = { key1: "value1", key2: "value2" };
+  
+      const result = getPropertyTitles(attachmentEntity, attachment);
+  
+      expect(result).toEqual({
+        property1: "key1",
+        property2: "Title 2",
+      });
+    });
+  
+    it("should skip keys without property names", () => {
+      const attachmentEntity = {
+        elements: {
+          key1: {
+            [sdmAnnotationAdditionalpropertyName]: "property1",
+            "@title": "Title 1",
+            name: "key1",
+          },
+          key2: {
+            "@title": "Title 2",
+            name: "key2",
+          },
+        },
+      };
+      const attachment = { key1: "value1", key2: "value2" };
+  
+      const result = getPropertyTitles(attachmentEntity, attachment);
+  
+      expect(result).toEqual({
+        property1: "Title 1",
+      });
+    });
+  
+    it("should return an empty map if attachment has no matching keys in attachmentEntity", () => {
+      const attachmentEntity = {
+        elements: {
+          key1: {
+            [sdmAnnotationAdditionalpropertyName]: "property1",
+            "@title": "Title 1",
+            name: "key1",
+          },
+        },
+      };
+      const attachment = { key2: "value2" };
+  
+      const result = getPropertyTitles(attachmentEntity, attachment);
+  
+      expect(result).toEqual({});
+    });
+  });
+
+  describe("getSecondaryPropertiesWithInvalidDefinition", () => {
+    it("should return an empty object if attachmentEntity is null", () => {
+      const attachmentEntity = null;
+      const attachment = { key1: "value1" };
+  
+      const result = getSecondaryPropertiesWithInvalidDefinition(attachmentEntity, attachment);
+  
+      expect(result).toEqual({});
+    });
+  
+    it("should return an empty object if no keys in attachment have outdated annotations", () => {
+      const attachmentEntity = {
+        elements: {
+          key1: {
+            name: "key1",
+            "@title": "Title 1",
+          },
+          key2: {
+            name: "key2",
+            "@title": "Title 2",
+          },
+        },
+      };
+      const attachment = { key1: "value1", key2: "value2" };
+  
+      const result = getSecondaryPropertiesWithInvalidDefinition(attachmentEntity, attachment);
+  
+      expect(result).toEqual({});
+    });
+  
+    it("should return a map of invalid properties with their titles when outdated annotations are present", () => {
+      const attachmentEntity = {
+        elements: {
+          key1: {
+            name: "key1",
+            "@title": "Title 1",
+            [sdmAnnotationAdditionalproperty]: true,
+          },
+          key2: {
+            name: "key2",
+            "@title": "Title 2",
+            [sdmAnnotationAdditionalproperty]: true,
+          },
+        },
+      };
+      const attachment = { key1: "value1", key2: "value2" };
+  
+      const result = getSecondaryPropertiesWithInvalidDefinition(attachmentEntity, attachment);
+  
+      expect(result).toEqual({
+        key1: "Title 1",
+        key2: "Title 2",
+      });
+    });
+  
+    it("should fallback to element name if @title annotation is not present", () => {
+      const attachmentEntity = {
+        elements: {
+          key1: {
+            name: "key1",
+            [sdmAnnotationAdditionalproperty]: true,
+          },
+          key2: {
+            name: "key2",
+            "@title": "Title 2",
+            [sdmAnnotationAdditionalproperty]: true,
+          },
+        },
+      };
+      const attachment = { key1: "value1", key2: "value2" };
+  
+      const result = getSecondaryPropertiesWithInvalidDefinition(attachmentEntity, attachment);
+  
+      expect(result).toEqual({
+        key1: "key1",
+        key2: "Title 2",
+      });
+    });
+  
+    it("should skip keys in attachment that do not exist in attachmentEntity.elements", () => {
+      const attachmentEntity = {
+        elements: {
+          key1: {
+            name: "key1",
+            "@title": "Title 1",
+            [sdmAnnotationAdditionalproperty]: true,
+          },
+        },
+      };
+      const attachment = { key1: "value1", key2: "value2" }; // key2 does not exist in attachmentEntity.elements
+  
+      const result = getSecondaryPropertiesWithInvalidDefinition(attachmentEntity, attachment);
+  
+      expect(result).toEqual({
+        key1: "Title 1",
+      });
+    });
+  });
+
+  describe("getSecondaryTypeProperties", () => {
+    it("should return an empty map if attachmentEntity is null", () => {
+      const attachmentEntity = null;
+      const attachment = { key1: "value1" };
+  
+      const result = getSecondaryTypeProperties(attachmentEntity, attachment);
+  
+      expect(result.size).toBe(0); // Map should be empty
+    });
+  
+    it("should return an empty map if no keys in attachment have annotations", () => {
+      const attachmentEntity = {
+        elements: {
+          key1: {
+            name: "key1",
+          },
+          key2: {
+            name: "key2",
+          },
+        },
+      };
+      const attachment = { key1: "value1", key2: "value2" };
+  
+      const result = getSecondaryTypeProperties(attachmentEntity, attachment);
+  
+      expect(result.size).toBe(0); // Map should be empty
+    });
+  
+    it("should return a map of secondary type properties when annotations are present", () => {
+      const attachmentEntity = {
+        elements: {
+          key1: {
+            name: "key1",
+            [sdmAnnotationAdditionalpropertyName]: "property1",
+          },
+          key2: {
+            name: "key2",
+            [sdmAnnotationAdditionalpropertyName]: "property2",
+          },
+        },
+      };
+      const attachment = { key1: "value1", key2: "value2" };
+  
+      const result = getSecondaryTypeProperties(attachmentEntity, attachment);
+  
+      expect(result.size).toBe(2);
+      expect(result.get("key1")).toBe("property1");
+      expect(result.get("key2")).toBe("property2");
+    });
+  
+    it("should skip keys in attachment that do not exist in attachmentEntity.elements", () => {
+      const attachmentEntity = {
+        elements: {
+          key1: {
+            name: "key1",
+            [sdmAnnotationAdditionalpropertyName]: "property1",
+          },
+        },
+      };
+      const attachment = { key1: "value1", key2: "value2" }; // key2 does not exist in attachmentEntity.elements
+  
+      const result = getSecondaryTypeProperties(attachmentEntity, attachment);
+  
+      expect(result.size).toBe(1);
+      expect(result.get("key1")).toBe("property1");
+      expect(result.has("key2")).toBe(false); // key2 should not be in the map
+    });
+  
+    it("should handle cases where annotations are missing for some keys", () => {
+      const attachmentEntity = {
+        elements: {
+          key1: {
+            name: "key1",
+            [sdmAnnotationAdditionalpropertyName]: "property1",
+          },
+          key2: {
+            name: "key2",
+          },
+        },
+      };
+      const attachment = { key1: "value1", key2: "value2" };
+  
+      const result = getSecondaryTypeProperties(attachmentEntity, attachment);
+  
+      expect(result.size).toBe(1);
+      expect(result.get("key1")).toBe("property1");
+      expect(result.has("key2")).toBe(false); // key2 should not be in the map
+    });
+  });
+
+  describe("getUpdatedSecondaryProperties", () => {
+    it("should return an empty object if there are no differences between attachment and database values", () => {
+      const attachment = { property1: "value1", property2: "value2" };
+      const secondaryTypeProperties = new Map([
+        ["property1", "dbProperty1"],
+        ["property2", "dbProperty2"],
+      ]);
+      const propertiesInDB = { dbProperty1: "value1", dbProperty2: "value2" };
+  
+      const result = getUpdatedSecondaryProperties(attachment, secondaryTypeProperties, propertiesInDB);
+  
+      expect(result).toEqual({});
+    });
+  
+    it("should update properties when attachment value is null and database value is not null", () => {
+      const attachment = { property1: null, property2: "value2" };
+      const secondaryTypeProperties = new Map([
+        ["property1", "dbProperty1"],
+        ["property2", "dbProperty2"],
+      ]);
+      const propertiesInDB = { dbProperty1: "value1", dbProperty2: "value2" };
+  
+      const result = getUpdatedSecondaryProperties(attachment, secondaryTypeProperties, propertiesInDB);
+  
+      expect(result).toEqual({ dbProperty1: null });
+    });
+  
+    it("should update properties when attachment value differs from database value", () => {
+      const attachment = { property1: "newValue1", property2: "value2" };
+      const secondaryTypeProperties = new Map([
+        ["property1", "dbProperty1"],
+        ["property2", "dbProperty2"],
+      ]);
+      const propertiesInDB = { dbProperty1: "value1", dbProperty2: "value2" };
+  
+      const result = getUpdatedSecondaryProperties(attachment, secondaryTypeProperties, propertiesInDB);
+  
+      expect(result).toEqual({ dbProperty1: "newValue1" });
+    });
+  
+    it("should handle cases where database value is null and attachment value is not null", () => {
+      const attachment = { property1: "value1", property2: "value2" };
+      const secondaryTypeProperties = new Map([
+        ["property1", "dbProperty1"],
+        ["property2", "dbProperty2"],
+      ]);
+      const propertiesInDB = { dbProperty1: null, dbProperty2: "value2" };
+  
+      const result = getUpdatedSecondaryProperties(attachment, secondaryTypeProperties, propertiesInDB);
+  
+      expect(result).toEqual({ dbProperty1: "value1" });
+    });
+  
+    it("should handle cases where both attachment and database values are null", () => {
+      const attachment = { property1: null, property2: "value2" };
+      const secondaryTypeProperties = new Map([
+        ["property1", "dbProperty1"],
+        ["property2", "dbProperty2"],
+      ]);
+      const propertiesInDB = { dbProperty1: null, dbProperty2: "value2" };
+  
+      const result = getUpdatedSecondaryProperties(attachment, secondaryTypeProperties, propertiesInDB);
+  
+      expect(result).toEqual({});
+    });
+  
+    it("should handle cases where secondaryTypeProperties is empty", () => {
+      const attachment = { property1: "value1", property2: "value2" };
+      const secondaryTypeProperties = new Map(); // Empty map
+      const propertiesInDB = { dbProperty1: "value1", dbProperty2: "value2" };
+  
+      const result = getUpdatedSecondaryProperties(attachment, secondaryTypeProperties, propertiesInDB);
+  
+      expect(result).toEqual({});
+    });
+  });
+
+  describe("extractSecondaryTypeIds", () => {
+    it("should extract type IDs from a flat JSON array", () => {
+      const jsonArray = [
+        { type: { id: "type1" } },
+        { type: { id: "type2" } },
+        { type: { id: "type3" } },
+      ];
+      const result = [];
+  
+      extractSecondaryTypeIds(jsonArray, result);
+  
+      expect(result).toEqual(["type1", "type2", "type3"]);
+    });
+  
+    it("should extract type IDs from a nested JSON array", () => {
+      const jsonArray = [
+        {
+          type: { id: "type1" },
+          children: [
+            { type: { id: "type2" } },
+            { type: { id: "type3" } },
+          ],
+        },
+        { type: { id: "type4" } },
+      ];
+      const result = [];
+  
+      extractSecondaryTypeIds(jsonArray, result);
+  
+      expect(result).toEqual(["type1", "type2", "type3", "type4"]);
+    });
+  
+    it("should handle JSON objects without a type ID", () => {
+      const jsonArray = [
+        { type: { id: "type1" } },
+        { type: {} }, // No ID
+        { children: [{ type: { id: "type2" } }] }, // Nested with valid ID
+      ];
+      const result = [];
+  
+      extractSecondaryTypeIds(jsonArray, result);
+  
+      expect(result).toEqual(["type1", "type2"]);
+    });
+  
+    it("should handle an empty JSON array", () => {
+      const jsonArray = [];
+      const result = [];
+  
+      extractSecondaryTypeIds(jsonArray, result);
+  
+      expect(result).toEqual([]);
+    });
+  
+    it("should handle a JSON array with no valid type IDs", () => {
+      const jsonArray = [
+        { type: {} },
+        { children: [{ type: {} }] },
+      ];
+      const result = [];
+  
+      extractSecondaryTypeIds(jsonArray, result);
+  
+      expect(result).toEqual([]);
+    });
+  
+    it("should not modify the result array if no type IDs are found", () => {
+      const jsonArray = [
+        { type: {} },
+        { children: [{ type: {} }] },
+      ];
+      const result = ["existingType"];
+  
+      extractSecondaryTypeIds(jsonArray, result);
+  
+      expect(result).toEqual(["existingType"]);
+    });
+  });
+
+  describe("checkMCM", () => {
+    it("should return false if responseBody is null or empty", () => {
+      const responseBody = "";
+      const secondaryPropertyIds = [];
+  
+      const result = checkMCM(responseBody, secondaryPropertyIds);
+  
+      expect(result).toBe(false);
+      expect(secondaryPropertyIds).toEqual([]);
+    });
+  
+    it("should return false if responseBody does not contain propertyDefinitions", () => {
+      const responseBody = JSON.stringify({ someOtherKey: {} });
+      const secondaryPropertyIds = [];
+  
+      const result = checkMCM(responseBody, secondaryPropertyIds);
+  
+      expect(result).toBe(false);
+      expect(secondaryPropertyIds).toEqual([]);
+    });
+  
+    it("should return false if propertyDefinitions is null or undefined", () => {
+      const responseBody = JSON.stringify({ propertyDefinitions: null });
+      const secondaryPropertyIds = [];
+  
+      const result = checkMCM(responseBody, secondaryPropertyIds);
+  
+      expect(result).toBe(false);
+      expect(secondaryPropertyIds).toEqual([]);
+    });
+  
+    it("should return true and add keys to secondaryPropertyIds if isPartOfTable is 'true'", () => {
+      const responseBody = JSON.stringify({
+        propertyDefinitions: {
+          key1: { "mcm:miscellaneous": { isPartOfTable: "true" } },
+          key2: { "mcm:miscellaneous": { isPartOfTable: "false" } },
+          key3: { "mcm:miscellaneous": { isPartOfTable: "true" } },
+        },
+      });
+      const secondaryPropertyIds = [];
+  
+      const result = checkMCM(responseBody, secondaryPropertyIds);
+  
+      expect(result).toBe(true);
+      expect(secondaryPropertyIds).toEqual(["key1", "key3"]);
+    });
+  
+    it("should return false if no properties have isPartOfTable set to 'true'", () => {
+      const responseBody = JSON.stringify({
+        propertyDefinitions: {
+          key1: { "mcm:miscellaneous": { isPartOfTable: "false" } },
+          key2: { "mcm:miscellaneous": { isPartOfTable: "false" } },
+        },
+      });
+      const secondaryPropertyIds = [];
+  
+      const result = checkMCM(responseBody, secondaryPropertyIds);
+  
+      expect(result).toBe(false);
+      expect(secondaryPropertyIds).toEqual([]);
+    });
+  
+    it("should handle cases where propertyDefinitions has no mcm:miscellaneous key", () => {
+      const responseBody = JSON.stringify({
+        propertyDefinitions: {
+          key1: {},
+          key2: { "mcm:miscellaneous": { isPartOfTable: "false" } },
+        },
+      });
+      const secondaryPropertyIds = [];
+  
+      const result = checkMCM(responseBody, secondaryPropertyIds);
+  
+      expect(result).toBe(false);
+      expect(secondaryPropertyIds).toEqual([]);
+    });
+  
+    it("should handle invalid JSON in responseBody", () => {
+      const responseBody = "invalid JSON";
+      const secondaryPropertyIds = [];
+  
+      expect(() => checkMCM(responseBody, secondaryPropertyIds)).toThrow(SyntaxError);
+    });
+  });
+
+  describe("prepareSecondaryProperties", () => {
+    let formData;
+  
+    beforeEach(() => {
+      formData = {
+        append: jest.fn(), // Mock the append method
+      };
+    });
+  
+    it("should append secondary properties to FormData", () => {
+      const secondaryProperties = {
+        key1: "value1",
+        key2: "value2",
+      };
+  
+      prepareSecondaryProperties(formData, secondaryProperties);
+  
+      expect(formData.append).toHaveBeenCalledTimes(4);
+      expect(formData.append).toHaveBeenCalledWith("propertyId[1]", "key1");
+      expect(formData.append).toHaveBeenCalledWith("propertyValue[1]", "value1");
+      expect(formData.append).toHaveBeenCalledWith("propertyId[2]", "key2");
+      expect(formData.append).toHaveBeenCalledWith("propertyValue[2]", "value2");
+    });
+  
+    it("should handle the 'filename' key and map it to 'cmis:name'", () => {
+      const secondaryProperties = {
+        filename: "testFileName",
+      };
+  
+      prepareSecondaryProperties(formData, secondaryProperties);
+  
+      expect(formData.append).toHaveBeenCalledTimes(2);
+      expect(formData.append).toHaveBeenCalledWith("propertyId[1]", "cmis:name");
+      expect(formData.append).toHaveBeenCalledWith("propertyValue[1]", "testFileName");
+    });
+  
+    it("should handle an empty secondaryProperties object", () => {
+      const secondaryProperties = {};
+  
+      prepareSecondaryProperties(formData, secondaryProperties);
+  
+      expect(formData.append).not.toHaveBeenCalled();
+    });
+  
+    it("should handle multiple secondary properties including 'filename'", () => {
+      const secondaryProperties = {
+        filename: "testFileName",
+        key1: "value1",
+        key2: "value2",
+      };
+  
+      prepareSecondaryProperties(formData, secondaryProperties);
+  
+      expect(formData.append).toHaveBeenCalledTimes(6);
+      expect(formData.append).toHaveBeenCalledWith("propertyId[1]", "cmis:name");
+      expect(formData.append).toHaveBeenCalledWith("propertyValue[1]", "testFileName");
+      expect(formData.append).toHaveBeenCalledWith("propertyId[2]", "key1");
+      expect(formData.append).toHaveBeenCalledWith("propertyValue[2]", "value1");
+      expect(formData.append).toHaveBeenCalledWith("propertyId[3]", "key2");
+      expect(formData.append).toHaveBeenCalledWith("propertyValue[3]", "value2");
     });
   });
 });


### PR DESCRIPTION
## Describe your changes
This PR adds support for custom properties in plugin.


#### Any documentation
https://wiki.one.int.sap/wiki/display/sapecm/Custom+Types+Support+for+NodeJs+plugin

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist before requesting a review

- [x] I have tested the functionality on my cloud environment.
- [x] I have  provided sufficient automated/ unit tests for the code.
- [x] I have increased or maintained the test coverage.
- [x] I have ran integration tests on my cloud environment.
- [x] I have validated blackduck portal for any vulnerability after my commit.

Lists of the scenarios tested

- Create Entity, upload an attachment. Upload same attachment again. Click on Save.
- Create Entity, upload an attachment. Discard draft.
- Create Entity, upload an attachment. Upload same attachment again. Click on Save. Delete the entity.
- Create Entity, upload 3 attachments. **For attachment-1** update the name of the attachment and update the valid custom properties for Integer, boolean, Date type and select a value from drop down for String type. **For attachment-2** update valid custom properties for Integer, boolean, Date type and select a value from drop-down for String type and input a string for invalid types(MCM is partOfTable is not present). For **attachment-3** update the name of the attachment and update valid custom properties for Integer, boolean, Date type and select a value from drop-down for String type. Click on Save. Only attachment-1 & attachment-3 is updated and updated secondary properties values for attachment-2 is reverted back and Warning is thrown for invalid properties.
- Edit the entity created in previous test. **For attachment-1** update the name of the attachment and in attachment name add "/" in name and update valid custom properties for Integer, boolean, Date type and select a value from drop down for String type. **For attachment-2** update the name of the attachment and update valid custom properties for Integer, boolean, Date type and select a value from drop-down for String type. For **attachment-3** update valid custom properties for Integer, boolean, Date type and select a value from drop-down for String type and input a string for invalid types(MCM is partOfTable is not present). Click on Save. Only attachment-2 is updated and updated secondary properties values for attachment-1 & attachment-3 is reverted back and Warning is thrown for invalid properties and special character in filename for attachment-1.

<img width="811" alt="Screenshot 2025-06-24 at 4 16 04 PM" src="https://github.com/user-attachments/assets/6a7eac84-5f4c-46e4-bfd5-3d871bbd7463" />

