### PR TITLE
fixed Internal server error when repositoryID is configured incorrectly

### DIFF
--- a/lib/handler/index.js
+++ b/lib/handler/index.js
@@ -51,12 +51,12 @@ async function getRepositoryInfo(req, credentials, token) {
     const response = await axios.get(getRepoInfoUrl, config);
     return response;
   } catch (error) {
-      if(error.response?.status===404){
-        req.reject(404, "Failed to get repository info");
-      }
-      else if (error.response?.status === 500) {
-        req.reject(500, error.response.data?.message);
-      }
+    if (error.response?.status === 404) {
+      req.reject(404, "Failed to get repository info");
+    }
+    else if (error.response?.status === 500) {
+      req.reject(500, error.response.data?.message);
+    }
     throw new Error(error);
   }
 }

--- a/lib/handler/index.js
+++ b/lib/handler/index.js
@@ -54,6 +54,9 @@ async function getRepositoryInfo(req, credentials, token) {
     if(error.response?.status===404){
       req.reject(404, "Failed to get repository info");
     }
+    else if (error.response?.status === 500) {
+      req.reject(500, error.response.data?.message);
+   }
     throw new Error(error);
   }
 }

--- a/lib/handler/index.js
+++ b/lib/handler/index.js
@@ -37,7 +37,7 @@ async function readDocument(Key, token, uri) {
   }
 }
 
-async function getRepositoryInfo(credentials, token) {
+async function getRepositoryInfo(req, credentials, token) {
   const { repositoryId } = getConfigurations();
   const getRepoInfoUrl =
     credentials.uri +
@@ -51,6 +51,9 @@ async function getRepositoryInfo(credentials, token) {
     const response = await axios.get(getRepoInfoUrl, config);
     return response;
   } catch (error) {
+    if(error.response?.status===404){
+      req.reject(404, "Failed to get repository info");
+    }
     throw new Error(error);
   }
 }

--- a/lib/handler/index.js
+++ b/lib/handler/index.js
@@ -51,12 +51,12 @@ async function getRepositoryInfo(req, credentials, token) {
     const response = await axios.get(getRepoInfoUrl, config);
     return response;
   } catch (error) {
-    if(error.response?.status===404){
-      req.reject(404, "Failed to get repository info");
-    }
-    else if (error.response?.status === 500) {
-      req.reject(500, error.response.data?.message);
-   }
+      if(error.response?.status===404){
+        req.reject(404, "Failed to get repository info");
+      }
+      else if (error.response?.status === 500) {
+        req.reject(500, error.response.data?.message);
+      }
     throw new Error(error);
   }
 }

--- a/lib/sdm.js
+++ b/lib/sdm.js
@@ -75,7 +75,7 @@ module.exports = class SDMAttachmentsService extends (
     let isVersioned;
     if (repotype == undefined) {
       const token = await getClientCredentialsToken(this.creds);
-      const repoInfo = await getRepositoryInfo(this.creds, token);
+      const repoInfo = await getRepositoryInfo(req, this.creds, token);
       isVersioned = await isRepositoryVersioned(repoInfo, repositoryId); 
     } else { 
       isVersioned = repotype == "versioned";

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   "devDependencies": {
     "@cap-js/sqlite": "^1",
     "@eslint/js": "^9.4.0",
-    "@sap/cds-dk": "^8.1.2",
+    "@sap/cds-dk": "8.9.5",
     "eslint": "^9.4.0",
     "eslint-plugin-jest": "^28.5.0",
     "globals": "^15.3.0",

--- a/test/lib/handler/index.test.js
+++ b/test/lib/handler/index.test.js
@@ -120,9 +120,10 @@ describe("handlers", () => {
   });
 
   describe("getRepositoryInfo", () => {
-    let mockedCredentials, mockedToken, mockRepoInfo;
+    let mockedCredentials, mockedToken, mockRepoInfo, mockReq;
     beforeEach(() => {
       jest.clearAllMocks();
+      mockReq = { reject: jest.fn() };
     });
 
     it("should return repositoryInfo for provided repositoryId", async () => {
@@ -139,7 +140,7 @@ describe("handlers", () => {
       }
       const mockUrl = mockedCredentials.uri + "browser/" + 123 + "?cmisselector=repositoryInfo";
       axios.get.mockResolvedValue(mockRepoInfo);
-      const repoInfo = await getRepositoryInfo(mockedCredentials, mockedToken);
+      const repoInfo = await getRepositoryInfo(mockReq, mockedCredentials, mockedToken);
       expect(axios.get).toHaveBeenCalledWith(mockUrl, {
         headers: { Authorization: `Bearer ${mockedToken}` }
       });
@@ -153,7 +154,7 @@ describe("handlers", () => {
         Promise.reject("something bad happened")
       );
       await expect(
-        getRepositoryInfo(mockedCredentials, mockedToken)
+        getRepositoryInfo(mockReq, mockedCredentials, mockedToken)
       ).rejects.toThrow("something bad happened");
     });
   })

--- a/test/lib/sdm.test.js
+++ b/test/lib/sdm.test.js
@@ -138,7 +138,7 @@ describe("SDMAttachmentsService", () => {
       await service.checkRepositoryType(mockReq);
   
       expect(getClientCredentialsToken).toHaveBeenCalledWith(service.creds);
-      expect(getRepositoryInfo).toHaveBeenCalledWith(service.creds, "mock-token");
+      expect(getRepositoryInfo).toHaveBeenCalledWith(mockReq, service.creds, "mock-token");
       expect(isRepositoryVersioned).toHaveBeenCalledWith({ data: "mock-repo-info" }, "repo123");
       expect(mockReq.reject).not.toHaveBeenCalled();
     });
@@ -162,7 +162,7 @@ describe("SDMAttachmentsService", () => {
       await service.checkRepositoryType(mockReq);
   
       expect(getClientCredentialsToken).toHaveBeenCalledWith(service.creds);
-      expect(getRepositoryInfo).toHaveBeenCalledWith(service.creds, "mock-token");
+      expect(getRepositoryInfo).toHaveBeenCalledWith(mockReq, service.creds, "mock-token");
       expect(isRepositoryVersioned).toHaveBeenCalledWith({ data: "mock-repo-info" }, "repo123");
       expect(mockReq.reject).toHaveBeenCalledWith(400, versionedRepositoryErr);
     });


### PR DESCRIPTION
## Describe your changes
Updated error handling in the getRepositoryInfo method of the Node.js plugin.
Previously, if the repository was configured incorrectly (e.g., repo not found), the API would return a generic Internal Server Error

**Before fix**
![Screenshot 2025-06-24 at 4 38 12 PM (2)](https://github.com/user-attachments/assets/30763a3d-fd51-4c88-b468-5fd53bb29360)


**After fix**
<img width="2019" alt="Screenshot 2025-06-27 at 5 35 54 PM" src="https://github.com/user-attachments/assets/8f66c6d8-6123-40bb-b7ca-faf9ca61c350" />

**After Fix in Multitenancy Application**

<img width="2056" alt="Screenshot 2025-07-02 at 4 12 02 PM" src="https://github.com/user-attachments/assets/e1953dea-9d84-4233-b3f4-47bd1526c2da" />


#### Any documentation

-

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist before requesting a review

- [x] I have tested the functionality on my cloud environment.
- [ ] I have  provided sufficient automated/ unit tests for the code.
- [ ] I have increased or maintained the test coverage.
- [ ] I have ran integration tests on my cloud environment.
- [ ] I have validated blackduck portal for any vulnerability after my commit.

## Upload Screenshots/lists of the scenarios tested
- [x] I have Uploaded Screenshots or added lists of the scenarios tested in description


