### PR TITLE
Fix for read attachment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
+## Version 1.6.0
+
+### Added
+- Support custom properties in attachments.
+
+### Fixed
+- Issue where users were unable to read attachments after uploading them.
+
 ## Version 1.5.1
 
 ### Fixed

--- a/lib/handler/index.js
+++ b/lib/handler/index.js
@@ -21,13 +21,12 @@ async function readDocument(Key, token, uri) {
     "&cmisselector=content";
   const config = {
     headers: { Authorization: `Bearer ${token}` },
-    responseType: "arraybuffer",
+    responseType: "stream",
   };
 
   try {
     const response = await axios.get(documentReadURL, config);
-    const responseBuffer = Buffer.from(response.data, "binary");
-    return responseBuffer;
+    return response.data;
   } catch (error) {
     if (error.message == "Request failed with status code 404" && error.status == 404){
       error.message = "Attachment not found in the repository"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cap-js/sdm",
   "description": "CAP plugin for effortless integration of CAP applications with SAP Document Management Service.",
-  "version": "1.5.2",
+  "version": "1.6.1",
   "repository": "cap-js/sdm",
   "author": "SAP SE (https://www.sap.com)",
   "homepage": "https://cap.cloud.sap/",

--- a/test/integration/attachments-sdm.test.js
+++ b/test/integration/attachments-sdm.test.js
@@ -96,10 +96,6 @@ describe('Attachments Integration Tests --CREATE', () => {
       { 
         filename: "samplebig.pdf", 
         filepath: "./test/integration/samplebig.pdf" 
-      },
-      { 
-        filename: "invalid.pdf", 
-        filepath: "./test/integration/invalid.pdf" 
       }
     ];
 

--- a/test/lib/handler/index.test.js
+++ b/test/lib/handler/index.test.js
@@ -54,7 +54,6 @@ describe("handlers", () => {
       const mockCredentials = { uri: "http://example.com/" };
 
       const mockResponse = { data: "mock pdf file content" };
-      const mockBuffer = Buffer.from(mockResponse.data, "binary");
 
       axios.get.mockResolvedValue(mockResponse);
 
@@ -71,9 +70,9 @@ describe("handlers", () => {
         "&cmisselector=content";
       expect(axios.get).toHaveBeenCalledWith(expectedUrl, {
         headers: { Authorization: `Bearer ${mockToken}` },
-        responseType: "arraybuffer",
+        responseType: "stream",
       });
-      expect(document).toEqual(mockBuffer);
+      expect(document).toEqual(mockResponse.data);
     });
 
     it("throws error on unsuccessful read", async () => {


### PR DESCRIPTION
## Describe your changes
This PR fixes the ReadAttachment issue that was there with latest cds update. Till now we returned content buffer after reading the it from SDM. This buffer was further processed by CDS library to display the attachment. However with recent releases they stopped processing content buffer and expected content to be instance of Readable. This was the reason ReadAttachments was failing. With this PR we now return content which is instance of Readable.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist before requesting a review

- [x] I have tested the functionality on my cloud environment.
- [x] I have  provided sufficient automated/ unit tests for the code.
- [x] I have increased or maintained the test coverage.
- [x] I have ran integration tests on my cloud environment.
- [x] I have validated blackduck portal for any vulnerability after my commit.

## Upload Screenshots/lists of the scenarios tested
- [x] I have Uploaded Screenshots or added lists of the scenarios tested in description

<img width="802" alt="Screenshot 2025-07-02 at 7 01 04 PM" src="https://github.com/user-attachments/assets/a83ca7e1-3b9d-4b71-9dec-740d541f5919" />



