### PR TITLE
Issue-132:Error on upload

### DIFF
--- a/lib/persistence/index.js
+++ b/lib/persistence/index.js
@@ -74,7 +74,7 @@ async function getFolderIdForEntity(attachments, req, repositoryId) {
 async function updateAttachmentInDraft(req, data) {
   return await UPDATE(req.target)
     .set({ folderId: data.folderId, url: data.url, status: "Clean" })
-    .where({ ["ID"]: req.data["ID"] });
+    .where({ ["ID"]: req.params[1].ID});
 }
 
 async function getURLsToDeleteFromAttachments(deletedAttachments, attachments) {

--- a/lib/sdm.js
+++ b/lib/sdm.js
@@ -545,7 +545,7 @@ module.exports = class SDMAttachmentsService extends (
   async attachURLsToDeleteFromAttachmentsDraft(req) {
     let draftAttachments = cds.model.definitions[req.query.target.name];
     if(draftAttachments)  {
-      const attachmentsToDeleteFromDraft = await getURLToDeleteFromDraftAttachments(req.params[1].ID, draftAttachments);
+      const attachmentsToDeleteFromDraft = await getURLToDeleteFromDraftAttachments(req.data.ID, draftAttachments);
       if (attachmentsToDeleteFromDraft?.length > 0) {
         req.attachmentsToDelete = attachmentsToDeleteFromDraft;
       }

--- a/lib/sdm.js
+++ b/lib/sdm.js
@@ -361,7 +361,7 @@ module.exports = class SDMAttachmentsService extends (
       const attachment_val = await getDraftAttachmentsForUpID(draftAttachments, req, repositoryId);
 
       if (attachment_val.length > 0) {
-        const attachmentToUpload = attachment_val.find(attachment => attachment.ID === req.data.ID);
+        const attachmentToUpload = attachment_val.find(attachment => attachment.ID === req.data.params[0].ID);
         const filename = attachmentToUpload ? attachmentToUpload.filename : null;
         if (filename) {
           const nameConstraint = isRestrictedCharactersInName(filename);
@@ -376,7 +376,7 @@ module.exports = class SDMAttachmentsService extends (
         );
         let attachment_val_create = [];
         if (req.data.content) {
-          attachment_val_create = attachment_val.filter(attachment => attachment.HasActiveEntity === false && attachment.ID === req.data.ID);
+          attachment_val_create = attachment_val.filter(attachment => attachment.HasActiveEntity === false && attachment.ID === req.data.params[0].ID);
         }
         if(attachment_val_create.length>0){
           attachment_val_create[0].content = req.data.content;
@@ -519,7 +519,7 @@ module.exports = class SDMAttachmentsService extends (
   async attachDraftDeletionData(req) {
     let draftAttachments = cds.model.definitions[req.query.target.name.replace(/\.drafts$/, ".attachments.drafts")];
     if(draftAttachments)  {
-      const attachmentsToDeleteFromDraft = await getURLsToDeleteFromDraftAttachments(req.data.ID, draftAttachments);
+      const attachmentsToDeleteFromDraft = await getURLsToDeleteFromDraftAttachments(req.data.params[0].ID, draftAttachments);
       if (attachmentsToDeleteFromDraft?.length > 0) {
         req.attachmentsToDelete = attachmentsToDeleteFromDraft;
       }
@@ -545,7 +545,7 @@ module.exports = class SDMAttachmentsService extends (
   async attachURLsToDeleteFromAttachmentsDraft(req) {
     let draftAttachments = cds.model.definitions[req.query.target.name];
     if(draftAttachments)  {
-      const attachmentsToDeleteFromDraft = await getURLToDeleteFromDraftAttachments(req.data.ID, draftAttachments);
+      const attachmentsToDeleteFromDraft = await getURLToDeleteFromDraftAttachments(req.data.params[0].ID, draftAttachments);
       if (attachmentsToDeleteFromDraft?.length > 0) {
         req.attachmentsToDelete = attachmentsToDeleteFromDraft;
       }

--- a/lib/sdm.js
+++ b/lib/sdm.js
@@ -361,7 +361,7 @@ module.exports = class SDMAttachmentsService extends (
       const attachment_val = await getDraftAttachmentsForUpID(draftAttachments, req, repositoryId);
 
       if (attachment_val.length > 0) {
-        const attachmentToUpload = attachment_val.find(attachment => attachment.ID === req.params[0].ID);
+        const attachmentToUpload = attachment_val.find(attachment => attachment.ID === req.params[1].ID);
         const filename = attachmentToUpload ? attachmentToUpload.filename : null;
         if (filename) {
           const nameConstraint = isRestrictedCharactersInName(filename);
@@ -376,7 +376,7 @@ module.exports = class SDMAttachmentsService extends (
         );
         let attachment_val_create = [];
         if (req.data.content) {
-          attachment_val_create = attachment_val.filter(attachment => attachment.HasActiveEntity === false && attachment.ID === req.params[0].ID);
+          attachment_val_create = attachment_val.filter(attachment => attachment.HasActiveEntity === false && attachment.ID === req.params[1].ID);
         }
         if(attachment_val_create.length>0){
           attachment_val_create[0].content = req.data.content;
@@ -519,7 +519,7 @@ module.exports = class SDMAttachmentsService extends (
   async attachDraftDeletionData(req) {
     let draftAttachments = cds.model.definitions[req.query.target.name.replace(/\.drafts$/, ".attachments.drafts")];
     if(draftAttachments)  {
-      const attachmentsToDeleteFromDraft = await getURLsToDeleteFromDraftAttachments(req.params[0].ID, draftAttachments);
+      const attachmentsToDeleteFromDraft = await getURLsToDeleteFromDraftAttachments(req.data.ID, draftAttachments);
       if (attachmentsToDeleteFromDraft?.length > 0) {
         req.attachmentsToDelete = attachmentsToDeleteFromDraft;
       }
@@ -545,7 +545,7 @@ module.exports = class SDMAttachmentsService extends (
   async attachURLsToDeleteFromAttachmentsDraft(req) {
     let draftAttachments = cds.model.definitions[req.query.target.name];
     if(draftAttachments)  {
-      const attachmentsToDeleteFromDraft = await getURLToDeleteFromDraftAttachments(req.params[0].ID, draftAttachments);
+      const attachmentsToDeleteFromDraft = await getURLToDeleteFromDraftAttachments(req.params[1].ID, draftAttachments);
       if (attachmentsToDeleteFromDraft?.length > 0) {
         req.attachmentsToDelete = attachmentsToDeleteFromDraft;
       }

--- a/lib/sdm.js
+++ b/lib/sdm.js
@@ -361,7 +361,7 @@ module.exports = class SDMAttachmentsService extends (
       const attachment_val = await getDraftAttachmentsForUpID(draftAttachments, req, repositoryId);
 
       if (attachment_val.length > 0) {
-        const attachmentToUpload = attachment_val.find(attachment => attachment.ID === req.data.params[0].ID);
+        const attachmentToUpload = attachment_val.find(attachment => attachment.ID === req.params[0].ID);
         const filename = attachmentToUpload ? attachmentToUpload.filename : null;
         if (filename) {
           const nameConstraint = isRestrictedCharactersInName(filename);
@@ -376,7 +376,7 @@ module.exports = class SDMAttachmentsService extends (
         );
         let attachment_val_create = [];
         if (req.data.content) {
-          attachment_val_create = attachment_val.filter(attachment => attachment.HasActiveEntity === false && attachment.ID === req.data.params[0].ID);
+          attachment_val_create = attachment_val.filter(attachment => attachment.HasActiveEntity === false && attachment.ID === req.params[0].ID);
         }
         if(attachment_val_create.length>0){
           attachment_val_create[0].content = req.data.content;
@@ -519,7 +519,7 @@ module.exports = class SDMAttachmentsService extends (
   async attachDraftDeletionData(req) {
     let draftAttachments = cds.model.definitions[req.query.target.name.replace(/\.drafts$/, ".attachments.drafts")];
     if(draftAttachments)  {
-      const attachmentsToDeleteFromDraft = await getURLsToDeleteFromDraftAttachments(req.data.params[0].ID, draftAttachments);
+      const attachmentsToDeleteFromDraft = await getURLsToDeleteFromDraftAttachments(req.params[0].ID, draftAttachments);
       if (attachmentsToDeleteFromDraft?.length > 0) {
         req.attachmentsToDelete = attachmentsToDeleteFromDraft;
       }
@@ -545,7 +545,7 @@ module.exports = class SDMAttachmentsService extends (
   async attachURLsToDeleteFromAttachmentsDraft(req) {
     let draftAttachments = cds.model.definitions[req.query.target.name];
     if(draftAttachments)  {
-      const attachmentsToDeleteFromDraft = await getURLToDeleteFromDraftAttachments(req.data.params[0].ID, draftAttachments);
+      const attachmentsToDeleteFromDraft = await getURLToDeleteFromDraftAttachments(req.params[0].ID, draftAttachments);
       if (attachmentsToDeleteFromDraft?.length > 0) {
         req.attachmentsToDelete = attachmentsToDeleteFromDraft;
       }

--- a/test/lib/sdm.test.js
+++ b/test/lib/sdm.test.js
@@ -1380,11 +1380,14 @@ describe("SDMAttachmentsService", () => {
   
     test('should handle drafts when attachment values are found', async () => {
       const draftAttachments = [];
-      const req = { data: { content: 'some content' }, params: [
-                                                                                                                  {
-                                                                                                                    ID: '12345'
-                                                                                                                  }
-                                                                                                                ],target: draftAttachments, user: { tokenInfo: { getTokenValue: jest.fn().mockReturnValue('mockTokenValue') } } };
+      const req = { data: {  content: 'some content' }, params: [
+                                                                 {
+                                                                   ID: '12345'
+                                                                 },
+                                                                 {
+                                                                             ID: '12345'
+                                                                           }
+                                                               ],target: draftAttachments, user: { tokenInfo: { getTokenValue: jest.fn().mockReturnValue('mockTokenValue') } } };
 
       const token = 'token123';
       const attachment_val = [
@@ -1410,7 +1413,10 @@ describe("SDMAttachmentsService", () => {
         params: [
           {
             ID: '12345'
-          }
+          },
+          {
+                      ID: '12345'
+                    }
         ],
         target: draftAttachments,
         user: {
@@ -1463,7 +1469,9 @@ describe("SDMAttachmentsService", () => {
     });
     test('should reject when filename contains restricted characters', async () => {
       const draftAttachments = [];
-      const req = { data: { content: 'some content' },params:[{ID: '12345'}], target: draftAttachments, user: { tokenInfo: { getTokenValue: jest.fn().mockReturnValue('mockTokenValue') } }, reject: jest.fn() };
+      const req = { data: { content: 'some content' },params:[{ID: '12345'},{
+                                                                                                  ID: '12345'
+                                                                                                }], target: draftAttachments, user: { tokenInfo: { getTokenValue: jest.fn().mockReturnValue('mockTokenValue') } }, reject: jest.fn() };
       const token = 'token123';
       const attachment_val = [
         { HasActiveEntity: false, ID: '12345', filename: 'invalid/name' },
@@ -1483,7 +1491,9 @@ describe("SDMAttachmentsService", () => {
       const req = { data: { content: 'some content' },params: [
                                                                                                                  {
                                                                                                                    ID: '12345'
-                                                                                                                 }
+                                                                                                                 },{
+                                                                                                                                         ID: '12345'
+                                                                                                                                       }
                                                                                                                ] ,target: draftAttachments, user: { tokenInfo: { getTokenValue: jest.fn().mockReturnValue('mockTokenValue') } }, reject: jest.fn() };
       const token = 'token123';
       const attachment_val = [
@@ -1846,10 +1856,12 @@ describe("SDMAttachmentsService", () => {
         query: { target: { name: 'DraftAttachments' } },
         data:  {},
         params: [
-                                   {
-                                     ID: "some-id",
-                                   }
-                                 ],
+                                      {
+                                        ID: 'some-other-id'
+                                      },{
+                                                              ID: '12345'
+                                                            }
+                                    ] ,
         user: { tokenInfo: { getTokenValue: jest.fn().mockReturnValue("tokenValue") } },
       };
       cds.model.definitions["DraftAttachments"] = {};
@@ -1880,7 +1892,9 @@ describe("SDMAttachmentsService", () => {
         params: [
                               {
                                 ID: 'some-other-id'
-                              }
+                              },{
+                                                      ID: '12345'
+                                                    }
                             ] ,
         user: { tokenInfo: { getTokenValue: jest.fn().mockReturnValue("tokenValue") } },
       };
@@ -2382,11 +2396,14 @@ describe("SDMAttachmentsService", () => {
           },
         },
         data: {
+         ID: "mocked_id",
         },
          params: [
                      {
                        ID: "mocked_id",
-                     }
+                     },{
+                                             ID: 'mocked_id'
+                                           }
                    ],
         event: "DELETE",
         user: {

--- a/test/lib/sdm.test.js
+++ b/test/lib/sdm.test.js
@@ -1380,11 +1380,12 @@ describe("SDMAttachmentsService", () => {
   
     test('should handle drafts when attachment values are found', async () => {
       const draftAttachments = [];
-      const req = { data: { content: 'some content', params: [
-                                                           {
-                                                             ID: '12345'
-                                                           }
-                                                         ] }, target: draftAttachments, user: { tokenInfo: { getTokenValue: jest.fn().mockReturnValue('mockTokenValue') } } };
+      const req = { data: { content: 'some content' }, params: [
+                                                                                                                  {
+                                                                                                                    ID: '12345'
+                                                                                                                  }
+                                                                                                                ],target: draftAttachments, user: { tokenInfo: { getTokenValue: jest.fn().mockReturnValue('mockTokenValue') } } };
+
       const token = 'token123';
       const attachment_val = [
         { HasActiveEntity: false, ID: '12345' },
@@ -1402,12 +1403,23 @@ describe("SDMAttachmentsService", () => {
   
     test('should not create attachment if no matching inactive entities are found', async () => {
       const draftAttachments = [];
-      const req = { data: { content: 'some content', params: [
-                                                           {
-                                                             ID: '12345'
-                                                           }
-                                                         ] }, target: draftAttachments, user: { tokenInfo: { getTokenValue: jest.fn().mockReturnValue('mockTokenValue') } } };
-      const token = 'token123';
+      const req = {
+        data: {
+          content: 'some content'
+        },
+        params: [
+          {
+            ID: '12345'
+          }
+        ],
+        target: draftAttachments,
+        user: {
+          tokenInfo: {
+            getTokenValue: jest.fn().mockReturnValue('mockTokenValue')
+          }
+        }
+      };
+       const token = 'token123';
       const attachment_val = [{ HasActiveEntity: true, ID: '12345' }];
   
       getDraftAttachmentsForUpID.mockResolvedValue(attachment_val);
@@ -1451,7 +1463,7 @@ describe("SDMAttachmentsService", () => {
     });
     test('should reject when filename contains restricted characters', async () => {
       const draftAttachments = [];
-      const req = { data: { content: 'some content', params:[{ID: '12345'}] }, target: draftAttachments, user: { tokenInfo: { getTokenValue: jest.fn().mockReturnValue('mockTokenValue') } }, reject: jest.fn() };
+      const req = { data: { content: 'some content' },params:[{ID: '12345'}], target: draftAttachments, user: { tokenInfo: { getTokenValue: jest.fn().mockReturnValue('mockTokenValue') } }, reject: jest.fn() };
       const token = 'token123';
       const attachment_val = [
         { HasActiveEntity: false, ID: '12345', filename: 'invalid/name' },
@@ -1468,11 +1480,11 @@ describe("SDMAttachmentsService", () => {
   
     test('should not reject when filename does not contain restricted characters', async () => {
       const draftAttachments = [];
-      const req = { data: { content: 'some content', params: [
-                                                           {
-                                                             ID: '12345'
-                                                           }
-                                                         ] }, target: draftAttachments, user: { tokenInfo: { getTokenValue: jest.fn().mockReturnValue('mockTokenValue') } }, reject: jest.fn() };
+      const req = { data: { content: 'some content' },params: [
+                                                                                                                 {
+                                                                                                                   ID: '12345'
+                                                                                                                 }
+                                                                                                               ] ,target: draftAttachments, user: { tokenInfo: { getTokenValue: jest.fn().mockReturnValue('mockTokenValue') } }, reject: jest.fn() };
       const token = 'token123';
       const attachment_val = [
         { HasActiveEntity: false, ID: '12345', filename: 'validname' },
@@ -1832,11 +1844,12 @@ describe("SDMAttachmentsService", () => {
     it('should attach URLs to delete and call deleteAttachmentsWithKeys with correct data', async () => {
       const req = {
         query: { target: { name: 'DraftAttachments' } },
-        data:  {params: [
-                           {
-                             ID: "some-id",
-                           }
-                         ]},
+        data:  {},
+        params: [
+                                   {
+                                     ID: "some-id",
+                                   }
+                                 ],
         user: { tokenInfo: { getTokenValue: jest.fn().mockReturnValue("tokenValue") } },
       };
       cds.model.definitions["DraftAttachments"] = {};
@@ -1863,11 +1876,12 @@ describe("SDMAttachmentsService", () => {
   
       const req = {
         query: { target: { name: 'DraftAttachments' } },
-        data: { params: [
-                      {
-                        ID: 'some-other-id'
-                      }
-                    ] },
+        data: {},
+        params: [
+                              {
+                                ID: 'some-other-id'
+                              }
+                            ] ,
         user: { tokenInfo: { getTokenValue: jest.fn().mockReturnValue("tokenValue") } },
       };
       cds.model.definitions["DraftAttachments"] = {};
@@ -2368,12 +2382,12 @@ describe("SDMAttachmentsService", () => {
           },
         },
         data: {
-         params: [
-             {
-               ID: "mocked_id",
-             }
-           ],
         },
+         params: [
+                     {
+                       ID: "mocked_id",
+                     }
+                   ],
         event: "DELETE",
         user: {
           tokenInfo: {

--- a/test/lib/sdm.test.js
+++ b/test/lib/sdm.test.js
@@ -1380,7 +1380,11 @@ describe("SDMAttachmentsService", () => {
   
     test('should handle drafts when attachment values are found', async () => {
       const draftAttachments = [];
-      const req = { data: { content: 'some content', ID: '12345' }, target: draftAttachments, user: { tokenInfo: { getTokenValue: jest.fn().mockReturnValue('mockTokenValue') } } };
+      const req = { data: { content: 'some content', params: [
+                                                           {
+                                                             ID: '12345'
+                                                           }
+                                                         ] }, target: draftAttachments, user: { tokenInfo: { getTokenValue: jest.fn().mockReturnValue('mockTokenValue') } } };
       const token = 'token123';
       const attachment_val = [
         { HasActiveEntity: false, ID: '12345' },
@@ -1398,7 +1402,11 @@ describe("SDMAttachmentsService", () => {
   
     test('should not create attachment if no matching inactive entities are found', async () => {
       const draftAttachments = [];
-      const req = { data: { content: 'some content', ID: '12345' }, target: draftAttachments, user: { tokenInfo: { getTokenValue: jest.fn().mockReturnValue('mockTokenValue') } } };
+      const req = { data: { content: 'some content', params: [
+                                                           {
+                                                             ID: '12345'
+                                                           }
+                                                         ] }, target: draftAttachments, user: { tokenInfo: { getTokenValue: jest.fn().mockReturnValue('mockTokenValue') } } };
       const token = 'token123';
       const attachment_val = [{ HasActiveEntity: true, ID: '12345' }];
   
@@ -1443,7 +1451,7 @@ describe("SDMAttachmentsService", () => {
     });
     test('should reject when filename contains restricted characters', async () => {
       const draftAttachments = [];
-      const req = { data: { content: 'some content', ID: '12345' }, target: draftAttachments, user: { tokenInfo: { getTokenValue: jest.fn().mockReturnValue('mockTokenValue') } }, reject: jest.fn() };
+      const req = { data: { content: 'some content', params:[{ID: '12345'}] }, target: draftAttachments, user: { tokenInfo: { getTokenValue: jest.fn().mockReturnValue('mockTokenValue') } }, reject: jest.fn() };
       const token = 'token123';
       const attachment_val = [
         { HasActiveEntity: false, ID: '12345', filename: 'invalid/name' },
@@ -1460,7 +1468,11 @@ describe("SDMAttachmentsService", () => {
   
     test('should not reject when filename does not contain restricted characters', async () => {
       const draftAttachments = [];
-      const req = { data: { content: 'some content', ID: '12345' }, target: draftAttachments, user: { tokenInfo: { getTokenValue: jest.fn().mockReturnValue('mockTokenValue') } }, reject: jest.fn() };
+      const req = { data: { content: 'some content', params: [
+                                                           {
+                                                             ID: '12345'
+                                                           }
+                                                         ] }, target: draftAttachments, user: { tokenInfo: { getTokenValue: jest.fn().mockReturnValue('mockTokenValue') } }, reject: jest.fn() };
       const token = 'token123';
       const attachment_val = [
         { HasActiveEntity: false, ID: '12345', filename: 'validname' },
@@ -1820,7 +1832,11 @@ describe("SDMAttachmentsService", () => {
     it('should attach URLs to delete and call deleteAttachmentsWithKeys with correct data', async () => {
       const req = {
         query: { target: { name: 'DraftAttachments' } },
-        data: { ID: 'some-id' },
+        data:  {params: [
+                           {
+                             ID: "some-id",
+                           }
+                         ]},
         user: { tokenInfo: { getTokenValue: jest.fn().mockReturnValue("tokenValue") } },
       };
       cds.model.definitions["DraftAttachments"] = {};
@@ -1847,7 +1863,11 @@ describe("SDMAttachmentsService", () => {
   
       const req = {
         query: { target: { name: 'DraftAttachments' } },
-        data: { ID: 'some-other-id' },
+        data: { params: [
+                      {
+                        ID: 'some-other-id'
+                      }
+                    ] },
         user: { tokenInfo: { getTokenValue: jest.fn().mockReturnValue("tokenValue") } },
       };
       cds.model.definitions["DraftAttachments"] = {};
@@ -2348,7 +2368,11 @@ describe("SDMAttachmentsService", () => {
           },
         },
         data: {
-          ID: "mocked_id",
+         params: [
+             {
+               ID: "mocked_id",
+             }
+           ],
         },
         event: "DELETE",
         user: {


### PR DESCRIPTION
one of the customer set  odata-containment to 'true' in package.json "cds": {
"odata": {
"containment": true
}
It seems like req.data.ID is always empty using odata-containment. We need to use req.params[0].ID
which works for both containment true and false.
odata-containment will be made default true in futher cds releases for preventing DoS attacks.

## Describe your changes
Replaced req.data.ID with req.params[0].ID

#### Any documentation

-

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist before requesting a review

- [x] I have tested the functionality on my cloud environment.
- [x] I have  provided sufficient automated/ unit tests for the code.
- [x] I have increased or maintained the test coverage.
- [x] I have ran integration tests on my cloud environment.
- [x] I have validated blackduck portal for any vulnerability after my commit.

## Upload Screenshots/lists of the scenarios tested
- [x] I have Uploaded Screenshots or added lists of the scenarios tested in description


