### PR TITLE
Odata Containment

### DIFF
--- a/lib/persistence/index.js
+++ b/lib/persistence/index.js
@@ -74,7 +74,7 @@ async function getFolderIdForEntity(attachments, req, repositoryId) {
 async function updateAttachmentInDraft(req, data) {
   return await UPDATE(req.target)
     .set({ folderId: data.folderId, url: data.url, status: "Clean" })
-    .where({ ["ID"]: req.data["ID"] });
+    .where({ ["ID"]: req.params[1].ID });
 }
 
 async function getURLsToDeleteFromAttachments(deletedAttachments, attachments) {

--- a/lib/sdm.js
+++ b/lib/sdm.js
@@ -361,7 +361,7 @@ module.exports = class SDMAttachmentsService extends (
       const attachment_val = await getDraftAttachmentsForUpID(draftAttachments, req, repositoryId);
 
       if (attachment_val.length > 0) {
-        const attachmentToUpload = attachment_val.find(attachment => attachment.ID === req.data.ID);
+        const attachmentToUpload = attachment_val.find(attachment => attachment.ID === req.params[1].ID);
         const filename = attachmentToUpload ? attachmentToUpload.filename : null;
         if (filename) {
           const nameConstraint = isRestrictedCharactersInName(filename);
@@ -376,7 +376,7 @@ module.exports = class SDMAttachmentsService extends (
         );
         let attachment_val_create = [];
         if (req.data.content) {
-          attachment_val_create = attachment_val.filter(attachment => attachment.HasActiveEntity === false && attachment.ID === req.data.ID);
+          attachment_val_create = attachment_val.filter(attachment => attachment.HasActiveEntity === false && attachment.ID === req.params[1].ID);
         }
         if(attachment_val_create.length>0){
           attachment_val_create[0].content = req.data.content;

--- a/test/integration/api.js
+++ b/test/integration/api.js
@@ -166,17 +166,16 @@ class Api {
                 postData,
                 this.config
             )
-
             if (response.data && response.data.ID) {
                 const formDataPut = new FormData();
                 const pdfStream = fs.createReadStream(file.filepath); 
                 formDataPut.append('content', pdfStream);
                 // responseStatus.attachmentID.push(response.data.ID)
-            
-                try{
+                 try{
                     await axios.put(
-                    `https://${appUrl}/odata/v4/${serviceName}/Incidents_attachments(up__ID=${incidentID},ID=${response.data.ID},IsActiveEntity=false)/content`,
-                    formDataPut, 
+                     `https://${appUrl}/odata/v4/${serviceName}/${entityName}(ID=${incidentID},IsActiveEntity=false)/attachments(ID=${response.data.ID},IsActiveEntity=false)/content`,
+
+                    formDataPut,
                     this.config
                     );
 
@@ -265,13 +264,14 @@ class Api {
                 message: "Fetch metadata API call failed: " + error.message 
             };
         }
-    }    
+    }
 
     async updateAttachment(appUrl, serviceName, entityName, incidentID, updateData, attachment){
         let response;
-        try{
+         try{
+                                      );
             response = await axios.patch(
-                `https://${appUrl}/odata/v4/${serviceName}/${entityName}_attachments(up__ID=${incidentID},ID=${attachment},IsActiveEntity=false)`,
+               `https://${appUrl}/odata/v4/${serviceName}/${entityName}(ID=${incidentID},IsActiveEntity=false)/attachments(ID=${attachment},IsActiveEntity=false)`,
                 updateData,
                 this.config
             );
@@ -293,11 +293,11 @@ class Api {
         }   
     }
 
-    async deleteAttachment(appUrl, serviceName, incidentID, attachment){
+    async deleteAttachment(appUrl, serviceName, incidentID, attachment,entityName){
         let response;
         try{
             response = await axios.delete(
-                `https://${appUrl}/odata/v4/${serviceName}/Incidents_attachments(up__ID=${incidentID},ID=${attachment},IsActiveEntity=false)`,
+                 `https://${appUrl}/odata/v4/${serviceName}/${entityName}(ID=${incidentID},IsActiveEntity=false)/attachments(ID=${attachment},IsActiveEntity=false)`,
                 this.config
             );
             if (response.status === 204) {

--- a/test/integration/api.js
+++ b/test/integration/api.js
@@ -269,7 +269,6 @@ class Api {
     async updateAttachment(appUrl, serviceName, entityName, incidentID, updateData, attachment){
         let response;
          try{
-                                      );
             response = await axios.patch(
                `https://${appUrl}/odata/v4/${serviceName}/${entityName}(ID=${incidentID},IsActiveEntity=false)/attachments(ID=${attachment},IsActiveEntity=false)`,
                 updateData,

--- a/test/integration/attachments-sdm.test.js
+++ b/test/integration/attachments-sdm.test.js
@@ -75,14 +75,14 @@ describe('Attachments Integration Tests --CREATE', () => {
     }
   });
 
-  it('should upload a single attachment and check if it has been uploaded with content --exe', async () => { 
+  it('should upload a single attachment and check if it has been uploaded with content --exe', async () => {
     //A separate test case is formed for exe as the postData will vary, and unlike pdf it can't be viewed in browser
     const file =
-    { 
-      filename: "sample.exe", 
-      filepath: "./test/integration/sample.exe" 
+    {
+      filename: "sample.exe",
+      filepath: "./test/integration/sample.exe"
     }
-    
+
     const postData = {
       up__ID: incidentID,
       mimeType: "application/exe",
@@ -106,11 +106,11 @@ describe('Attachments Integration Tests --CREATE', () => {
     }
   });
 
-  it('should not allow upload of duplicate files in same entity', async () => { 
-    const file = 
-      { 
-        filename: "sample.pdf", 
-        filepath: "./test/integration/sample.pdf" 
+  it('should not allow upload of duplicate files in same entity', async () => {
+    const file =
+      {
+        filename: "sample.pdf",
+        filepath: "./test/integration/sample.pdf"
       }
 
     const postData = {
@@ -129,7 +129,7 @@ describe('Attachments Integration Tests --CREATE', () => {
     if (response.status == "OK") {
       throw new Error("Error : " + response.message)
     }
-    response = await api.deleteAttachment(appUrl, serviceName, incidentID, response.ID);
+    response = await api.deleteAttachment(appUrl, serviceName, incidentID, response.ID,entityName);
     if (response.status !== "OK") {
       throw new Error("Error : " + response.message)
     }
@@ -139,15 +139,15 @@ describe('Attachments Integration Tests --CREATE', () => {
     }
   });
 
-  it('should not allow upload of duplicate files in same entity --draft', async () => { 
+  it('should not allow upload of duplicate files in same entity --draft', async () => {
     const files = [
-      { 
-        filename: "sample2.pdf", 
-        filepath: "./test/integration/sample2.pdf" 
+      {
+        filename: "sample2.pdf",
+        filepath: "./test/integration/sample2.pdf"
       },
       {
-        filename: "sample2.pdf", 
-        filepath: "./test/integration/sample2.pdf" 
+        filename: "sample2.pdf",
+        filepath: "./test/integration/sample2.pdf"
       }
     ]
 
@@ -171,7 +171,7 @@ describe('Attachments Integration Tests --CREATE', () => {
     if (response.status == "OK") {
       throw new Error("Error : " + "Duplicate attachment was created")
     }
-    response = await api.deleteAttachment(appUrl, serviceName, incidentID, response.ID);
+    response = await api.deleteAttachment(appUrl, serviceName, incidentID, response.ID,entityName);
     if (response.status !== "OK") {
       throw new Error("Error : " + response.message)
     }
@@ -181,17 +181,17 @@ describe('Attachments Integration Tests --CREATE', () => {
     }
   });
 
-  it('should allow upload of a duplicate file in a different entity', async () => { 
+  it('should allow upload of a duplicate file in a different entity', async () => {
     let response = await api.createEntityDraft(appUrl, serviceName, entityName, srvpath);
     if (response.status !== "OK") {
       throw new Error("Error : " + response.message)
     }
     incidentToDelete = response.incidentID;
 
-    const file = 
-    { 
-      filename: "sample.pdf", 
-      filepath: "./test/integration/sample.pdf" 
+    const file =
+    {
+      filename: "sample.pdf",
+      filepath: "./test/integration/sample.pdf"
     }
 
     const postData = {
@@ -240,11 +240,11 @@ describe('Attachments Integration Tests --UPDATE', () => {
 
   it('should update valid properties of attachments during create of entity', async () => {
     let response = await api.createEntityDraft(appUrl, serviceName, entityName, srvpath);
+
     if (response.status !== "OK") {
       throw new Error("Error : " + response.message)
     }
     incidentIDCustomProperty1 = response.incidentID;
-
     const postData = {
       up__ID: incidentIDCustomProperty1,
       mimeType: "application/pdf",
@@ -253,18 +253,17 @@ describe('Attachments Integration Tests --UPDATE', () => {
       modifiedBy: "test@test.com"
     }
 
-    const file = 
-    { 
-      filename: "sample.pdf", 
-      filepath: "./test/integration/sample.pdf" 
-    }    
+    const file =
+    {
+      filename: "sample.pdf",
+      filepath: "./test/integration/sample.pdf"
+    }
 
     response = await api.createAttachment(appUrl, serviceName, entityName, incidentIDCustomProperty1, postData, file);
     if (response.status !== "OK") {
       throw new Error("Error : " + response.message)
     }
     attachment1 = response.ID;
-
     let updateData = {
       filename : "sample_updated.pdf",
       customProperty1_code: "test",
@@ -296,7 +295,7 @@ describe('Attachments Integration Tests --UPDATE', () => {
     if (response.status !== "OK") {
       throw new Error("Error : " + response.message)
     }
-    
+
     let updateData = {
       filename : "sample_updated1.pdf",
       customProperty1_code: "test123",
@@ -339,16 +338,16 @@ describe('Attachments Integration Tests --UPDATE', () => {
     }
 
     const files = [
-      { 
-        filename: "sample.pdf", 
-        filepath: "./test/integration/sample.pdf" 
+      {
+        filename: "sample.pdf",
+        filepath: "./test/integration/sample.pdf"
       },
       {
-        filename: "sample2.pdf", 
-        filepath: "./test/integration/sample2.pdf" 
-      } 
+        filename: "sample2.pdf",
+        filepath: "./test/integration/sample2.pdf"
+      }
     ]
-       
+
 
     response = await api.createAttachment(appUrl, serviceName, entityName, incidentIDCustomProperty2, postData, files[0]);
     if (response.status !== "OK") {
@@ -418,7 +417,7 @@ describe('Attachments Integration Tests --UPDATE', () => {
     if (response.status !== "OK") {
       throw new Error("Error : " + response.message)
     }
-    
+
     let updateDataInvalid = {
       filename : "sample_updated_invalid.pdf",
       customProperty1_code: "test123",
@@ -477,7 +476,7 @@ describe('Attachments Integration Tests --DELETE', () => {
     if (response.status !== "OK") {
       throw new Error("Error : " + response.message)
     }
-    response = await api.deleteAttachment(appUrl, serviceName, incidentID, attachments[0]);
+    response = await api.deleteAttachment(appUrl, serviceName, incidentID, attachments[0],entityName);
     if (response.status !== "OK") {
       throw new Error("Error : " + response.message)
     }

--- a/test/integration/credentials.json
+++ b/test/integration/credentials.json
@@ -1,8 +1,8 @@
 {
-    "appUrl" : "sdmgoogleworkspacedev-rashmicap-incidents-srv.cfapps.eu12.hana.ondemand.com",
-    "authUrl": "https://sdmgoogleworkspace.authentication.eu12.hana.ondemand.com",
-    "clientID": "sb-sdmincidentsRash!t5256",
-    "clientSecret": "63741f0a-3487-487b-8d48-4dce980f6985$b5TSQiiuoo-NL6g8sFuSGSR_EoF7CGdUerNYLsS3ljU=",
-    "username":"dl_624e58a16fe2da029b4f0cc2@global.corp.sap",
-    "password":"Gwi_int1"
+    "appUrl" : "APP_URL",
+    "authUrl": "AUTH_URL",
+    "clientID": "CLIENT_ID",
+    "clientSecret": "CLIENT_SECRET",
+    "username": "USER_EMAIL",
+    "password": "USER_PASSWORD"
 }

--- a/test/integration/credentials.json
+++ b/test/integration/credentials.json
@@ -1,8 +1,8 @@
 {
-    "appUrl" : "APP_URL",
-    "authUrl": "AUTH_URL",
-    "clientID": "CLIENT_ID",
-    "clientSecret": "CLIENT_SECRET",
-    "username": "USER_EMAIL",
-    "password": "USER_PASSWORD"
+    "appUrl" : "sdmgoogleworkspacedev-rashmicap-incidents-srv.cfapps.eu12.hana.ondemand.com",
+    "authUrl": "https://sdmgoogleworkspace.authentication.eu12.hana.ondemand.com",
+    "clientID": "sb-sdmincidentsRash!t5256",
+    "clientSecret": "63741f0a-3487-487b-8d48-4dce980f6985$b5TSQiiuoo-NL6g8sFuSGSR_EoF7CGdUerNYLsS3ljU=",
+    "username":"dl_624e58a16fe2da029b4f0cc2@global.corp.sap",
+    "password":"Gwi_int1"
 }

--- a/test/lib/sdm.test.js
+++ b/test/lib/sdm.test.js
@@ -1378,8 +1378,15 @@ describe("SDMAttachmentsService", () => {
   
     test('should handle drafts when attachment values are found', async () => {
       const draftAttachments = [];
-      const req = { data: { content: 'some content', ID: '12345' }, target: draftAttachments, user: { tokenInfo: { getTokenValue: jest.fn().mockReturnValue('mockTokenValue') } } };
-      const token = 'token123';
+     const req = { data: {  content: 'some content' }, params: [
+                                                                      {
+                                                                        ID: '12345'
+                                                                      },
+                                                                      {
+                                                                                  ID: '12345'
+                                                                                }
+                                                                    ],target: draftAttachments, user: { tokenInfo: { getTokenValue: jest.fn().mockReturnValue('mockTokenValue') } } };
+                                                                     const token = 'token123';
       const attachment_val = [
         { HasActiveEntity: false, ID: '12345' },
         { HasActiveEntity: true, ID: '67890' },
@@ -1396,8 +1403,26 @@ describe("SDMAttachmentsService", () => {
   
     test('should not create attachment if no matching inactive entities are found', async () => {
       const draftAttachments = [];
-      const req = { data: { content: 'some content', ID: '12345' }, target: draftAttachments, user: { tokenInfo: { getTokenValue: jest.fn().mockReturnValue('mockTokenValue') } } };
-      const token = 'token123';
+      const req = {
+              data: {
+                content: 'some content'
+              },
+              params: [
+                {
+                  ID: '12345'
+                },
+                {
+                            ID: '12345'
+                          }
+              ],
+              target: draftAttachments,
+              user: {
+                tokenInfo: {
+                  getTokenValue: jest.fn().mockReturnValue('mockTokenValue')
+                }
+              }
+            };
+             const token = 'token123';
       const attachment_val = [{ HasActiveEntity: true, ID: '12345' }];
   
       getDraftAttachmentsForUpID.mockResolvedValue(attachment_val);
@@ -1441,8 +1466,10 @@ describe("SDMAttachmentsService", () => {
     });
     test('should reject when filename contains restricted characters', async () => {
       const draftAttachments = [];
-      const req = { data: { content: 'some content', ID: '12345' }, target: draftAttachments, user: { tokenInfo: { getTokenValue: jest.fn().mockReturnValue('mockTokenValue') } }, reject: jest.fn() };
-      const token = 'token123';
+      const req = { data: { content: 'some content' },params:[{ID: '12345'},{
+                                                                                                        ID: '12345'
+                                                                                                      }], target: draftAttachments, user: { tokenInfo: { getTokenValue: jest.fn().mockReturnValue('mockTokenValue') } }, reject: jest.fn() };
+          const token = 'token123';
       const attachment_val = [
         { HasActiveEntity: false, ID: '12345', filename: 'invalid/name' },
         { HasActiveEntity: true, ID: '67890' },
@@ -1458,23 +1485,29 @@ describe("SDMAttachmentsService", () => {
   
     test('should not reject when filename does not contain restricted characters', async () => {
       const draftAttachments = [];
-      const req = { data: { content: 'some content', ID: '12345' }, target: draftAttachments, user: { tokenInfo: { getTokenValue: jest.fn().mockReturnValue('mockTokenValue') } }, reject: jest.fn() };
-      const token = 'token123';
-      const attachment_val = [
-        { HasActiveEntity: false, ID: '12345', filename: 'validname' },
-        { HasActiveEntity: true, ID: '67890' },
-      ];
-      getDraftAttachmentsForUpID.mockResolvedValue(attachment_val);
-      fetchAccessToken.mockResolvedValue(token);
-      isRestrictedCharactersInName.mockReturnValue(false);
-  
-      await service.draftSaveHandler(req);
-  
-      expect(req.reject).not.toHaveBeenCalled();
-      expect(service.create).toHaveBeenCalledWith([{ ...attachment_val[0], content: 'some content' }], draftAttachments, req, token);
-      expect(req.data.content).toBeNull();
-    });
-  });
+           const req = { data: { content: 'some content' },params: [
+                                                                                                                      {
+                                                                                                                        ID: '12345'
+                                                                                                                      },{
+                                                                                                                                              ID: '12345'
+                                                                                                                                            }
+                                                                                                                    ] ,target: draftAttachments, user: { tokenInfo: { getTokenValue: jest.fn().mockReturnValue('mockTokenValue') } }, reject: jest.fn() };
+           const token = 'token123';
+           const attachment_val = [
+             { HasActiveEntity: false, ID: '12345', filename: 'validname' },
+             { HasActiveEntity: true, ID: '67890' },
+           ];
+           getDraftAttachmentsForUpID.mockResolvedValue(attachment_val);
+           fetchAccessToken.mockResolvedValue(token);
+           isRestrictedCharactersInName.mockReturnValue(false);
+
+           await service.draftSaveHandler(req);
+
+           expect(req.reject).not.toHaveBeenCalled();
+           expect(service.create).toHaveBeenCalledWith([{ ...attachment_val[0], content: 'some content' }], draftAttachments, req, token);
+           expect(req.data.content).toBeNull();
+         });
+       });
 
   describe("filterAttachments", () => {
     let service;
@@ -1801,26 +1834,26 @@ describe("SDMAttachmentsService", () => {
     
     it('should attach URLs to delete and call deleteAttachmentsWithKeys with correct data', async () => {
       const req = {
-        target: { name: 'DraftAttachments' },
-        data: { ID: 'some-id' },
-        user: { tokenInfo: { getTokenValue: jest.fn().mockReturnValue("tokenValue") } },
-      };
-      cds.model.definitions["DraftAttachments"] = {};
-  
-      // Define a mock function on the service instance to observe it being called
-      const deleteAttachmentsSpy = jest.spyOn(service, 'deleteAttachmentsWithKeys');
-      
-      // Call the method
-      await service.attachURLsToDeleteFromAttachmentsDraft(req);
-      
-      expect(req.attachmentsToDelete).toEqual([{ url: 'http://example.com/attachment1', ID: '1' }]);
-      
-      // Validate deleteAttachmentsWithKeys has been called
-      expect(deleteAttachmentsSpy).toHaveBeenCalled();
-      
-      // Validate deleteAttachmentsWithKeys is called with the correct arguments
-      expect(deleteAttachmentsSpy).toHaveBeenCalledWith(req.attachmentsToDelete, req);
-    });
+              target: {   name: 'DraftAttachments'  },
+              data:  { ID: 'some-other-id'},
+              user: { tokenInfo: { getTokenValue: jest.fn().mockReturnValue("tokenValue") } },
+            };
+            cds.model.definitions["DraftAttachments"] = {};
+
+            // Define a mock function on the service instance to observe it being called
+            const deleteAttachmentsSpy = jest.spyOn(service, 'deleteAttachmentsWithKeys');
+
+            // Call the method
+            await service.attachURLsToDeleteFromAttachmentsDraft(req);
+
+            expect(req.attachmentsToDelete).toEqual([{ url: 'http://example.com/attachment1', ID: '1' }]);
+
+            // Validate deleteAttachmentsWithKeys has been called
+            expect(deleteAttachmentsSpy).toHaveBeenCalled();
+
+            // Validate deleteAttachmentsWithKeys is called with the correct arguments
+            expect(deleteAttachmentsSpy).toHaveBeenCalledWith(req.attachmentsToDelete, req);
+          });
     
     it('should not call deleteAttachmentsWithKeys if there are no attachments to delete', async () => {
       getURLToDeleteFromDraftAttachments.mockImplementationOnce(async () => {


### PR DESCRIPTION
F**ixes the issue https://github.com/cap-js/sdm/issues/132**

## Describe your changes
one of the customer set odata-containment to 'true' in package.json "cds": {
"odata": {
"containment": true
}
It seems like req.data.ID is always empty using odata-containment. We need to use req.params[0].ID
which works for both containment true and false.
odata-containment will be made default true in futher cds releases for preventing DoS attacks.



#### Any documentation
Replaced req.data.ID with req.params[0].ID
-

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist before requesting a review

- [x] I have tested the functionality on my cloud environment.
- [x] I have  provided sufficient automated/ unit tests for the code.
- [x] I have increased or maintained the test coverage.
- [x] I have ran integration tests on my cloud environment.
- [x] I have validated blackduck portal for any vulnerability after my commit.

## Upload Screenshots/lists of the scenarios tested
- [ ] I have Uploaded Screenshots or added lists of the scenarios tested in description


