### PR TITLE
offboard repository changes

### DIFF
--- a/lib/mtx/repository-store.js
+++ b/lib/mtx/repository-store.js
@@ -1,0 +1,30 @@
+const fs = require('fs');
+const path = require('path');
+
+const STORE_PATH = path.join(__dirname, 'repository-map.json');
+
+const readStore = () => {
+    if (!fs.existsSync(STORE_PATH)) {
+        fs.writeFileSync(STORE_PATH, '{}');
+    }
+    return JSON.parse(fs.readFileSync(STORE_PATH));
+};
+
+const writeStore = (data) => {
+    fs.writeFileSync(STORE_PATH, JSON.stringify(data, null, 2));
+};
+
+// Save repository ID per tenant
+const saveRepositoryId = (tenant, repoId) => {
+    const store = readStore();
+    store[tenant] = repoId;
+    writeStore(store);
+};
+
+// Retrieve repository ID for tenant
+const getRepositoryId = (tenant) => {
+    const store = readStore();
+    return store[tenant];
+};
+
+module.exports = { saveRepositoryId, getRepositoryId };

--- a/lib/mtx/server.js
+++ b/lib/mtx/server.js
@@ -57,7 +57,7 @@ if (profile === "mtx-sidecar") {
 
     try {
         const response = await axios.post(url, repositoryObject, { headers });
-            return response.data;
+        return response.data;
     } catch (error) {
         throw error?.response?.data || error;
     }

--- a/lib/mtx/server.js
+++ b/lib/mtx/server.js
@@ -58,9 +58,9 @@ if (profile === "mtx-sidecar") {
     try {
         const response = await axios.post(url, repositoryObject, { headers });
             return response.data;
-        } catch (error) {
-            throw error?.response?.data || error;
-        }
+    } catch (error) {
+        throw error?.response?.data || error;
+    }
     };
 
     // === Helper to DELETE the repository object from SDM ===

--- a/lib/mtx/server.js
+++ b/lib/mtx/server.js
@@ -4,6 +4,7 @@ const axios = require('axios');
 const path = require('path');
 const requests = xssec.v3.requests;
 const { getConfigurations } = require("../util/index");
+const { saveRepositoryId, getRepositoryId } = require("./repository-store");
 const profile = cds.env.profile;
 let configPath;
 
@@ -56,10 +57,24 @@ if (profile === "mtx-sidecar") {
 
     try {
         const response = await axios.post(url, repositoryObject, { headers });
-        return response;
-    } catch (error) {
-        throw error?.response?.data || error;
-    }
+            return response.data;
+        } catch (error) {
+            throw error?.response?.data || error;
+        }
+    };
+
+    // === Helper to DELETE the repository object from SDM ===
+    const offboardRepository = async (sdmUrl, repoId, token) => {
+        const url = `${sdmUrl}${repositoryUrl}/${repoId}`;
+        const headers = {
+            'Authorization': `Bearer ${token}`,
+        };
+
+        try {
+            await axios.delete(url, { headers });
+        } catch (error) {
+            throw error?.response?.data || error;
+        }
     };
 
     // === Hook into CAP subscription lifecycle ===
@@ -83,11 +98,41 @@ if (profile === "mtx-sidecar") {
         try {
             const repository = buildRepositoryObject();
             const token = await fetchSDMToken(subdomain, SDMCredentials.uaa);
-            await onboardRepository(sdmUrl, repository, token);
+            const onboardResponse = await onboardRepository(sdmUrl, repository, token);
             console.log("SDM repository onboarded");
+            if (onboardResponse?.id) {
+                saveRepositoryId(tenant, {
+                    repositoryId: onboardResponse.id,
+                    subdomain
+                });
+            }
         } catch (err) {
             console.error("Error during SDM onboarding:", err);
         }
         });
+
+    // On tenant unsubscribe
+    deploymentService.after('unsubscribe', async (_, req) => {
+        const { tenant } = req.data;
+        const SDMCredentials = cds.env.requires?.sdm?.credentials;
+        const sdmUrl = SDMCredentials?.uri;
+
+        console.log(`SDM Plugin: Tenant Unsubscription started — ${tenant}`);
+
+        try {
+            const tenantInfo = getRepositoryId(tenant);
+            if (!tenantInfo || !tenantInfo.repositoryId || !tenantInfo.subdomain) {
+                return;
+            }
+
+            const { repositoryId, subdomain } = tenantInfo;
+            const token = await fetchSDMToken(subdomain, SDMCredentials.uaa);
+            await offboardRepository(sdmUrl, repositoryId, token);
+            console.log("SDM repository offboarded");
+        } catch (err) {
+            console.error("Error during SDM offboarding:", err);
+            throw err;
+        }
+    });
     });
 }

--- a/test/lib/mtx/repository-store.test.js
+++ b/test/lib/mtx/repository-store.test.js
@@ -1,0 +1,56 @@
+const fs = require('fs');
+const path = require('path');
+
+const { saveRepositoryId, getRepositoryId } = require('../../../lib/mtx/repository-store');
+
+const STORE_PATH = path.join(__dirname, '../../../lib/mtx/repository-map.json');
+
+beforeEach(() => {
+    if (fs.existsSync(STORE_PATH)) {
+        fs.unlinkSync(STORE_PATH);
+    }
+});
+
+describe('Repository Store', () => {
+    test('should save and retrieve repository ID for a tenant', () => {
+        saveRepositoryId('tenant1', 'repo-123');
+        const repoId = getRepositoryId('tenant1');
+        expect(repoId).toBe('repo-123');
+    });
+
+    test('should overwrite repository ID if tenant already exists', () => {
+        saveRepositoryId('tenant1', 'repo-123');
+        saveRepositoryId('tenant1', 'repo-456');
+        const repoId = getRepositoryId('tenant1');
+        expect(repoId).toBe('repo-456');
+    });
+
+    test('should return undefined for non-existing tenant', () => {
+        const repoId = getRepositoryId('unknownTenant');
+        expect(repoId).toBeUndefined();
+    });
+
+    test('should persist data across multiple writes', () => {
+        saveRepositoryId('tenant1', 'repo-111');
+        saveRepositoryId('tenant2', 'repo-222');
+
+        const repo1 = getRepositoryId('tenant1');
+        const repo2 = getRepositoryId('tenant2');
+
+        expect(repo1).toBe('repo-111');
+        expect(repo2).toBe('repo-222');
+    });
+
+    test('should create repository-map.json if it does not exist', () => {
+        if (fs.existsSync(STORE_PATH)) {
+            fs.unlinkSync(STORE_PATH);
+        }
+        expect(fs.existsSync(STORE_PATH)).toBe(false);
+
+        saveRepositoryId('tenant1', 'repo-123');
+
+        expect(fs.existsSync(STORE_PATH)).toBe(true);
+        const repoId = getRepositoryId('tenant1');
+        expect(repoId).toBe('repo-123');
+    });
+});

--- a/test/lib/mtx/server.test.js
+++ b/test/lib/mtx/server.test.js
@@ -1,14 +1,17 @@
 jest.mock('axios');
 jest.mock('@sap/xssec');
 jest.mock('../../../lib/util/index');
+jest.mock('../../../lib/mtx/repository-store');
 const path = require('path');
 const messageConsts = require('../../../lib/util/messageConsts');
 
-describe('SDM Plugin Onboarding Logic', () => {
-    let axios, xssec, utils, mockCds, mockDeploymentService;
+describe('SDM Plugin Onboarding and Offboarding Logic', () => {
+    let axios, xssec, utils, mockCds, mockDeploymentService, mockRepoStore;
+    let subscribeCallback, unsubscribeCallback;
 
-    beforeEach(() => {
+    beforeEach(async () => {
         jest.resetModules();
+
         const MOCK_CONFIG = {
             sdm: {
                 repositoryConfig: {
@@ -37,12 +40,16 @@ describe('SDM Plugin Onboarding Logic', () => {
         axios = require('axios');
         xssec = require('@sap/xssec');
         utils = require('../../../lib/util/index');
+        mockRepoStore = require('../../../lib/mtx/repository-store');
 
-        axios.post.mockResolvedValue({ status: 201, data: 'Repository onboarded' });
+        axios.post.mockResolvedValue({ status: 201, data: { id: 'onboard-123' } });
+        axios.delete.mockResolvedValue({ status: 204, data: 'Repository offboarded' });
         xssec.v3.requests.requestClientCredentialsToken.mockImplementation((_, __, ___, cb) => cb(null, 'mock-jwt-token'));
         utils.getConfigurations.mockReturnValue({ repositoryId: 'ext-12345' });
+        mockRepoStore.getRepositoryId.mockReturnValue({ repositoryId: 'onboard-123', subdomain: 'mock-subdomain' });
 
         mockDeploymentService = { after: jest.fn() };
+
         mockCds = {
             connect: { to: jest.fn().mockResolvedValue(mockDeploymentService) },
             on: jest.fn(),
@@ -52,6 +59,26 @@ describe('SDM Plugin Onboarding Logic', () => {
 
         jest.doMock(MOCK_CONFIG_PATH, () => MOCK_CONFIG, { virtual: true });
         jest.doMock('@sap/cds', () => mockCds);
+
+        require('../../../lib/mtx/server');
+
+        const listeningCallback = mockCds.on.mock.calls.find(call => call[0] === 'listening')[1];
+        await listeningCallback();
+
+        expect(mockDeploymentService.after).toHaveBeenCalledTimes(2);
+
+        const subscribeCall = mockDeploymentService.after.mock.calls.find(call => call[0] === 'subscribe');
+        const unsubscribeCall = mockDeploymentService.after.mock.calls.find(call => call[0] === 'unsubscribe');
+
+        if (!subscribeCall || typeof subscribeCall[1] !== 'function') {
+            throw new Error("Failed to find 'subscribe' callback.");
+        }
+        if (!unsubscribeCall || typeof unsubscribeCall[1] !== 'function') {
+            throw new Error("Failed to find 'unsubscribe' callback.");
+        }
+
+        subscribeCallback = subscribeCall[1];
+        unsubscribeCallback = unsubscribeCall[1];
     });
 
     afterEach(() => {
@@ -59,76 +86,139 @@ describe('SDM Plugin Onboarding Logic', () => {
         jest.restoreAllMocks();
     });
 
-    const triggerSubscribe = async (reqData) => {
-        require('../../../lib/mtx/server');
-        const listeningCallback = mockCds.on.mock.calls.find(call => call[0] === 'listening')[1];
-        await listeningCallback();
-        const subscribeCallback = mockDeploymentService.after.mock.calls.find(call => call[0] === 'subscribe')[1];
-        await subscribeCallback({}, { data: reqData });
-    };
+    describe('Onboarding Logic', () => {
+        // ... (Onboarding tests are correct and unchanged) ...
+        it('should successfully onboard a tenant repository and save its ID on subscribe', async () => {
+            const consoleLogSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+            const mockReqData = { tenant: 't1', metadata: { subscribedSubdomain: 'tenant-a-subdomain' } };
 
-    it('should successfully onboard a tenant repository on subscribe', async () => {
-        const consoleLogSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
-        const mockReqData = { tenant: 't1', metadata: { subscribedSubdomain: 'tenant-a-subdomain' } };
-        await triggerSubscribe(mockReqData);
-        const expectedRepoObject = {
-            repository: {
-                description: "A test repository",
-                repositoryType: "com.sap.cloud.cmis.repository.ecm.system",
-                isVersionEnabled: "true",
-                externalId: 'ext-12345'
-            }
-        };
-        expect(axios.post).toHaveBeenCalledWith(
-            `https://mock-sdm-api.com${messageConsts.repositoryUrl}`,
-            expectedRepoObject,
-            expect.any(Object)
-        );
-        expect(consoleLogSpy).toHaveBeenCalledWith('SDM repository onboarded');
+            await subscribeCallback({}, { data: mockReqData });
+
+            const expectedRepoObject = {
+                repository: {
+                    description: "A test repository",
+                    repositoryType: "com.sap.cloud.cmis.repository.ecm.system",
+                    isVersionEnabled: "true",
+                    externalId: 'ext-12345'
+                }
+            };
+            expect(axios.post).toHaveBeenCalledWith(
+                `https://mock-sdm-api.com${messageConsts.repositoryUrl}`,
+                expectedRepoObject,
+                expect.any(Object)
+            );
+            expect(mockRepoStore.saveRepositoryId).toHaveBeenCalledWith('t1', {
+                repositoryId: 'onboard-123',
+                subdomain: 'tenant-a-subdomain'
+            });
+            expect(consoleLogSpy).toHaveBeenCalledWith('SDM repository onboarded');
+        });
+
+        it('should log an error if fetching the SDM token fails', async () => {
+            const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+            xssec.v3.requests.requestClientCredentialsToken.mockImplementationOnce((_, __, ___, cb) => cb(new Error("UAA connection failed")));
+            const mockReqData = { tenant: 't2', metadata: { subscribedSubdomain: 'tenant-b-subdomain' } };
+
+            await subscribeCallback({}, { data: mockReqData });
+
+            expect(axios.post).not.toHaveBeenCalled();
+            expect(consoleErrorSpy).toHaveBeenCalledWith("Error during SDM onboarding:", expect.any(Error));
+        });
+
+        it('should throw error if SDMRepositoryConfig.js is missing sdm key', () => {
+            const MOCK_CDS_ROOT = path.resolve(__dirname, '../../..');
+            const MOCK_CONFIG_PATH = path.join(MOCK_CDS_ROOT, 'SDMRepositoryConfig.js');
+            jest.resetModules();
+            jest.doMock(MOCK_CONFIG_PATH, () => ({}), { virtual: true });
+            mockCds.env.profile = 'mtx-sidecar';
+            jest.doMock('@sap/cds', () => mockCds);
+
+            expect(() => require('../../../lib/mtx/server')).toThrow(messageConsts.repositoryConfigurationMissing);
+        });
+
+        it('should log error if repositoryId or repositoryConfig is missing', async () => {
+            utils.getConfigurations.mockReturnValue({});
+            const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+            const mockReqData = { tenant: 't3', metadata: { subscribedSubdomain: 'tenant-c-subdomain' } };
+
+            await subscribeCallback({}, { data: mockReqData });
+
+            expect(consoleErrorSpy).toHaveBeenCalledWith("Error during SDM onboarding:", new Error(messageConsts.repositoryMissing));
+        });
+
+        it('should log error if onboardRepository fails', async () => {
+            axios.post.mockRejectedValueOnce({ response: { data: "POST failed" } });
+            const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+            const mockReqData = { tenant: 't4', metadata: { subscribedSubdomain: 'tenant-d-subdomain' } };
+
+            await subscribeCallback({}, { data: mockReqData });
+
+            expect(consoleErrorSpy).toHaveBeenCalledWith("Error during SDM onboarding:", "POST failed");
+        });
+
+        it('should log error if cds.xt.DeploymentService connection fails', async () => {
+            const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+            mockCds.connect.to.mockResolvedValueOnce(null);
+
+            jest.resetModules();
+            require('../../../lib/mtx/server');
+
+            const listeningCallback = mockCds.on.mock.calls.find(call => call[0] === 'listening')[1];
+            await listeningCallback();
+
+            expect(consoleErrorSpy).toHaveBeenCalledWith("Failed to connect to cds.xt.DeploymentService");
+        });
     });
 
-    it('should log an error if fetching the SDM token fails', async () => {
-        const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
-        xssec.v3.requests.requestClientCredentialsToken.mockImplementation((_, __, ___, cb) => cb(new Error("UAA connection failed")));
-        const mockReqData = { tenant: 't2', metadata: { subscribedSubdomain: 'tenant-b-subdomain' } };
-        await triggerSubscribe(mockReqData);
-        expect(axios.post).not.toHaveBeenCalled();
-        expect(consoleErrorSpy).toHaveBeenCalledWith("Error during SDM onboarding:", expect.any(Error));
-    });
+    describe('Offboarding Logic', () => {
+        it('should successfully offboard a tenant repository on unsubscribe', async () => {
+            const consoleLogSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+            const mockReqData = { tenant: 't5' };
 
-    it('should throw error if SDMRepositoryConfig.js is missing sdm key', () => {
-        const MOCK_CDS_ROOT = path.resolve(__dirname, '../../..');
-        const MOCK_CONFIG_PATH = path.join(MOCK_CDS_ROOT, 'SDMRepositoryConfig.js');
-        jest.doMock(MOCK_CONFIG_PATH, () => ({}), { virtual: true });
-        mockCds.env.profile = 'mtx-sidecar';
-        jest.doMock('@sap/cds', () => mockCds);
-        expect(() => require('../../../lib/mtx/server')).toThrow(messageConsts.repositoryConfigurationMissing);
-    });
+            await unsubscribeCallback({}, { data: mockReqData });
 
-    it('should throw error if repositoryId or repositoryConfig is missing', async () => {
-        utils.getConfigurations.mockReturnValue({}); // no repositoryId
-        const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
-        const mockReqData = { tenant: 't3', metadata: { subscribedSubdomain: 'tenant-c-subdomain' } };
-        await triggerSubscribe(mockReqData);
-        expect(consoleErrorSpy).toHaveBeenCalledWith("Error during SDM onboarding:", new Error(messageConsts.repositoryMissing));
-    });
+            expect(axios.delete).toHaveBeenCalledWith(
+                `https://mock-sdm-api.com${messageConsts.repositoryUrl}/onboard-123`,
+                { headers: { 'Authorization': 'Bearer mock-jwt-token' } }
+            );
+            expect(consoleLogSpy).toHaveBeenCalledWith('SDM repository offboarded');
+        });
 
-    it('should log error if onboardRepository fails', async () => {
-        axios.post.mockRejectedValue({ response: { data: "POST failed" } });
-        const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
-        const mockReqData = { tenant: 't4', metadata: { subscribedSubdomain: 'tenant-d-subdomain' } };
-        await triggerSubscribe(mockReqData);
-        expect(consoleErrorSpy).toHaveBeenCalledWith("Error during SDM onboarding:", "POST failed");
-    });
+        it('should throw an error if fetching the SDM token fails during offboarding', async () => {
+            xssec.v3.requests.requestClientCredentialsToken.mockImplementationOnce((_, __, ___, cb) => cb(new Error("UAA connection failed")));
+            const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+            const mockReqData = { tenant: 't6' };
 
-    it('should log error if cds.xt.DeploymentService connection fails', async () => {
-        const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
-        mockCds.connect.to.mockResolvedValueOnce(null); // force connection failure
+            await expect(unsubscribeCallback({}, { data: mockReqData })).rejects.toThrow("UAA connection failed");
 
-        require('../../../lib/mtx/server');
-        const listeningCallback = mockCds.on.mock.calls.find(call => call[0] === 'listening')[1];
-        await listeningCallback();
+            expect(axios.delete).not.toHaveBeenCalled();
+            expect(consoleErrorSpy).toHaveBeenCalledWith("Error during SDM offboarding:", expect.any(Error));
+        });
 
-        expect(consoleErrorSpy).toHaveBeenCalledWith("Failed to connect to cds.xt.DeploymentService");
+        it('should throw an error if offboardRepository fails', async () => {
+            const deleteError = { response: { data: "DELETE failed" } };
+            axios.delete.mockRejectedValueOnce(deleteError);
+
+            const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+            const mockReqData = { tenant: 't7' };
+
+            // --- THIS IS THE FIX ---
+            // We expect the promise to reject with the unwrapped string, not the original error object.
+            await expect(unsubscribeCallback({}, { data: mockReqData })).rejects.toEqual("DELETE failed");
+
+            expect(axios.delete).toHaveBeenCalledTimes(1);
+            expect(consoleErrorSpy).toHaveBeenCalledWith("Error during SDM offboarding:", "DELETE failed");
+        });
+
+        it('should return early if repositoryId is missing during offboarding', async () => {
+            mockRepoStore.getRepositoryId.mockReturnValueOnce(null);
+            const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+            const mockReqData = { tenant: 't8' };
+
+            await expect(unsubscribeCallback({}, { data: mockReqData })).resolves.toBeUndefined();
+
+            expect(axios.delete).not.toHaveBeenCalled();
+            expect(consoleErrorSpy).not.toHaveBeenCalled();
+        });
     });
 });

--- a/test/lib/mtx/server.test.js
+++ b/test/lib/mtx/server.test.js
@@ -9,6 +9,16 @@ describe('SDM Plugin Onboarding and Offboarding Logic', () => {
     let axios, xssec, utils, mockCds, mockDeploymentService, mockRepoStore;
     let subscribeCallback, unsubscribeCallback;
 
+    beforeAll(() => {
+        jest.spyOn(console, "log").mockImplementation(() => {});
+        jest.spyOn(console, "error").mockImplementation(() => {});
+    });
+
+    afterAll(() => {
+        console.log.mockRestore();
+        console.error.mockRestore();
+    });
+
     beforeEach(async () => {
         jest.resetModules();
 

--- a/test/lib/mtx/server.test.js
+++ b/test/lib/mtx/server.test.js
@@ -11,7 +11,6 @@ describe('SDM Plugin Onboarding and Offboarding Logic', () => {
 
     beforeEach(async () => {
         jest.resetModules();
-
         const MOCK_CONFIG = {
             sdm: {
                 repositoryConfig: {
@@ -47,9 +46,7 @@ describe('SDM Plugin Onboarding and Offboarding Logic', () => {
         xssec.v3.requests.requestClientCredentialsToken.mockImplementation((_, __, ___, cb) => cb(null, 'mock-jwt-token'));
         utils.getConfigurations.mockReturnValue({ repositoryId: 'ext-12345' });
         mockRepoStore.getRepositoryId.mockReturnValue({ repositoryId: 'onboard-123', subdomain: 'mock-subdomain' });
-
         mockDeploymentService = { after: jest.fn() };
-
         mockCds = {
             connect: { to: jest.fn().mockResolvedValue(mockDeploymentService) },
             on: jest.fn(),
@@ -87,7 +84,6 @@ describe('SDM Plugin Onboarding and Offboarding Logic', () => {
     });
 
     describe('Onboarding Logic', () => {
-        // ... (Onboarding tests are correct and unchanged) ...
         it('should successfully onboard a tenant repository and save its ID on subscribe', async () => {
             const consoleLogSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
             const mockReqData = { tenant: 't1', metadata: { subscribedSubdomain: 'tenant-a-subdomain' } };
@@ -202,8 +198,6 @@ describe('SDM Plugin Onboarding and Offboarding Logic', () => {
             const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
             const mockReqData = { tenant: 't7' };
 
-            // --- THIS IS THE FIX ---
-            // We expect the promise to reject with the unwrapped string, not the original error object.
             await expect(unsubscribeCallback({}, { data: mockReqData })).rejects.toEqual("DELETE failed");
 
             expect(axios.delete).toHaveBeenCalledTimes(1);

--- a/test/lib/mtx/server.test.js
+++ b/test/lib/mtx/server.test.js
@@ -9,16 +9,6 @@ describe('SDM Plugin Onboarding and Offboarding Logic', () => {
     let axios, xssec, utils, mockCds, mockDeploymentService, mockRepoStore;
     let subscribeCallback, unsubscribeCallback;
 
-    beforeAll(() => {
-        jest.spyOn(console, "log").mockImplementation(() => {});
-        jest.spyOn(console, "error").mockImplementation(() => {});
-    });
-
-    afterAll(() => {
-        console.log.mockRestore();
-        console.error.mockRestore();
-    });
-
     beforeEach(async () => {
         jest.resetModules();
 


### PR DESCRIPTION
## Describe your changes

Unsubscription functionality for multitenant applications using the SDM plugin.

This change makes sure that whenever a new tenant subscribes to our application, a corresponding repository is automatically created in SDM, and when the tenant unsubscribes, that repository is removed. To do this, we first read the SDMRepositoryConfig.js file, which contains the basic setup information about how a repository should look. Using this, along with a unique ID for each tenant, we build the final repository object that will be sent to SDM. To communicate with SDM, we fetch an access token, and then use it to make API calls – a POST request when creating (onboarding) the repository and a DELETE request when removing (offboarding) it.

To keep track of which tenant got which repository, we use a small local storage mechanism called repository-store.js, which reads and writes from a file named repository-map.json. This file is created automatically if it doesn’t exist, and it stores a simple mapping of tenant → repository details. This way, when a tenant unsubscribes, we know exactly which repository to delete from SDM.

In short: when a tenant comes in, we set up their repository in SDM and remember it in repository-map.json. When the tenant leaves, we look up their repository from the file and remove it from SDM. This makes the whole process of repository creation and deletion seamless, automated, and reliable.

#### Any documentation

-

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist before requesting a review

- [x] I have tested the functionality on my cloud environment.
- [x] I have  provided sufficient automated/ unit tests for the code.
- [x] I have increased or maintained the test coverage.
- [x] I have ran integration tests on my cloud environment.
- [ ] I have validated blackduck portal for any vulnerability after my commit.

## Upload Screenshots/lists of the scenarios tested
- [x] I have Uploaded Screenshots or added lists of the scenarios tested in description

repository offboarded successfully

<img width="738" height="500" alt="Screenshot 2025-08-19 at 3 55 54 PM" src="https://github.com/user-attachments/assets/0c0180a6-824d-4be9-92a8-df920dd93d33" />


After Unsubscription repository is securely deleted from the SDM

<img width="1009" height="1048" alt="Screenshot 2025-08-19 at 3 57 43 PM" src="https://github.com/user-attachments/assets/72409735-f43a-4112-b949-58c631113fbd" />


Integration Tests are successfully passing in Single Tenant Application with the changes.

<img width="2682" height="1226" alt="image" src="https://github.com/user-attachments/assets/9690a700-b00b-4026-a425-2f23acccfde5" />



