### PR TITLE
added Edge case for offboarding

### DIFF
--- a/lib/mtx/server.js
+++ b/lib/mtx/server.js
@@ -68,7 +68,12 @@ if (profile === "mtx-sidecar") {
         const headers = { 'Authorization': `Bearer ${token}` };
         try {
             const response = await axios.get(url, { headers });
-            return response.data?.repoAndConnectionInfos || [];
+            let repos = response.data?.repoAndConnectionInfos || [];
+            // if tenant has only one repository, return as array
+            if (!Array.isArray(repos)) {
+                repos = [repos];
+            }
+            return repos;
         } catch (error) {
             console.error("Error listing SDM repositories:", error?.response?.data || error);
             throw error;
@@ -133,8 +138,7 @@ if (profile === "mtx-sidecar") {
                 return;
             }
             const token = await fetchSDMToken(subdomain, SDMCredentials.uaa);
-            let allRepos = await listRepositories(sdmUrl, token);
-            allRepos = [ ...allRepos];
+            const allRepos = await listRepositories(sdmUrl, token);
             const repoToOffboard = allRepos.find(
                 repoInfo => repoInfo?.repository?.externalId === repositoryId
             );


### PR DESCRIPTION
## Describe your changes

The issue occurs during repository offboarding when a tenant has only a single repository. The GET /rest/v2/repositories API (https://api-sdm-di.cfapps.eu12.hana.ondemand.com/rest/v2/repositories) behaves differently based on the number of repositories:

Returns an object when the tenant has only one repository

Returns an array/list when the tenant has more than one repository

The offboarding logic was always expecting an array, which caused failures in the single-repository case.

Impact:
Offboarding fails for tenants with only one repository due to the type mismatch in the API response.

Fix:
Added an extra edge case in the offboarding logic. If the listRepositories API response is not an array, it is typecast into an array before further processing. This ensures consistent handling of both single and multiple repository scenarios.

#### Any documentation

-

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist before requesting a review

- [x] I have tested the functionality on my cloud environment.
- [x] I have  provided sufficient automated/ unit tests for the code.
- [ ] I have increased or maintained the test coverage.
- [ ] I have ran integration tests on my cloud environment.
- [ ] I have validated blackduck portal for any vulnerability after my commit.

## Upload Screenshots/lists of the scenarios tested
- [ ] I have Uploaded Screenshots or added lists of the scenarios tested in description


