### PR TITLE
Issue167:Accessing undefined variable in error handler

### DIFF
--- a/lib/util/index.js
+++ b/lib/util/index.js
@@ -38,7 +38,7 @@ async function generateSDMBearerToken(credentials, jwt) {
       null, null, subdomain, null, (error, response) => {
         if (error) {
           console.error(
-            `Response error while fetching access token ${response.statusCode}`
+            `Response error while fetching access token ${error}`
           );
           reject(err);
         } else {
@@ -92,7 +92,7 @@ async function getClientCredentialsToken(credentials) {
         (error, response) => {
           if (error) {
             console.error(
-              `Response error while fetching access token ${response.statusCode}`
+              `Response error while fetching access token ${error}`
             );
             reject(err);
           } else {

--- a/test/lib/util/index.test.js
+++ b/test/lib/util/index.test.js
@@ -197,7 +197,7 @@ describe("util", () => {
         expect(NodeCache.prototype.get).toBeCalledWith("example@example.com_subdomain");
         expect(xssec.v3.requests.requestUserToken).toBeCalled();
         expect(consoleErrorSpy).toBeCalledWith(
-          "Response error while fetching access token 500"
+          "Response error while fetching access token Error: test error"
         );
         expect(err).toBeInstanceOf(Error);
       } finally {


### PR DESCRIPTION
## Describe your changes
In case of an error, this callback function will only be called with the error object, but not with the response object from the @sap/xssec library (function requests.requestUserToken). Hence whenever it reaches this if block, it will run into an unhandled exception, because response will be undefined -> cannot read property 'statusCode' of undefined.

We encountered this issue, when e.g. the xsuaa server rejects the token exchange.

#### Any documentation
Removed statuscode and add error message
-

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist before requesting a review

- [x] I have tested the functionality on my cloud environment.
- [x] I have  provided sufficient automated/ unit tests for the code.
- [x] I have increased or maintained the test coverage.
- [x] I have ran integration tests on my cloud environment.
- [x] I have validated blackduck portal for any vulnerability after my commit.

## Upload Screenshots/lists of the scenarios tested
- [x] I have Uploaded Screenshots or added lists of the scenarios tested in description


