### PR TITLE
Plugin Implementation Prevents Local Application Testing and Execution of Unit Tests

### DIFF
--- a/lib/sdm.js
+++ b/lib/sdm.js
@@ -527,7 +527,7 @@ module.exports = class SDMAttachmentsService extends (
     if (attachments) {
       const diffData = await req.diff();
       let deletedAttachments = [];
-      if(diffData.attachments){
+      if(diffData.attachments.length>0){
         diffData.attachments
           .filter((object) => {
             return object._op === "delete";
@@ -605,11 +605,11 @@ module.exports = class SDMAttachmentsService extends (
   async deleteAttachmentsWithKeys(records, req) {
     let failedReq = [],
       Ids = [];
-    const token = await fetchAccessToken(
-      this.creds,
-      req.user.tokenInfo.getTokenValue()
-    );
     if (req?.attachmentsToDelete?.length > 0) {
+    const token = await fetchAccessToken(
+          this.creds,
+          req.user.tokenInfo.getTokenValue()
+        );
       if (req?.parentId) {
         await deleteFolderWithAttachments(this.creds, token, req.parentId);
       } else {

--- a/lib/sdm.js
+++ b/lib/sdm.js
@@ -377,6 +377,7 @@ module.exports = class SDMAttachmentsService extends (
   }
 
   async draftSaveHandler(req) {
+
     if (req?.data?.content) {
       const { repositoryId } = getConfigurations();
       await this.checkRepositoryType(req);
@@ -644,6 +645,10 @@ module.exports = class SDMAttachmentsService extends (
       }
     } else {
       if (req?.parentId) {
+       const token = await fetchAccessToken(
+                this.creds,
+                req.user.tokenInfo.getTokenValue()
+              );
         await deleteFolderWithAttachments(this.creds, token, req.parentId);
       }
     }

--- a/lib/sdm.js
+++ b/lib/sdm.js
@@ -527,7 +527,7 @@ module.exports = class SDMAttachmentsService extends (
     if (attachments) {
       const diffData = await req.diff();
       let deletedAttachments = [];
-      if(diffData.attachments.length>0){
+     if (diffData?.attachments?.length > 0) {
         diffData.attachments
           .filter((object) => {
             return object._op === "delete";

--- a/test/integration/attachments-sdm.test.js
+++ b/test/integration/attachments-sdm.test.js
@@ -507,4 +507,29 @@ describe('Attachments Integration Tests --DELETE', () => {
       throw new Error("Error : " + response.message)
     }
   });
+   it('should create an entity, edit and delete it without attachments', async () => {
+
+      let response = await api.createEntityDraft(appUrl, serviceName, entityName);
+      if (response.status !== "OK") {
+        throw new Error("Error : " + response.message)
+      }
+      incidentID = response.incidentID;
+
+      response = await api.saveEntityDraft(appUrl, serviceName, entityName, srvpath, incidentID);
+      if (response.status !== "OK") {
+        throw new Error("Error : " + response.message)
+      }
+      let editresponse = await api.editEntity(appUrl, serviceName, entityName, incidentID, srvpath);
+          if (editresponse.status !== "OK") {
+            throw new Error("Error : " + editresponse.message)
+          }
+            response = await api.saveEntityDraft(appUrl, serviceName, entityName, srvpath, incidentID);
+                if (response.status !== "OK") {
+                  throw new Error("Error : " + response.message)
+                }
+            let deleteresponse = await api.deleteEntity(appUrl, serviceName, entityName, incidentID);
+              if (deleteresponse.status !== "OK") {
+                throw new Error("Error : " + deleteresponse.message)
+              }
+    });
 });

--- a/test/lib/sdm.test.js
+++ b/test/lib/sdm.test.js
@@ -2059,22 +2059,14 @@ describe("SDMAttachmentsService", () => {
           },
         },
       };
-
-      fetchAccessToken.mockResolvedValueOnce("mocked_token");
-      deleteFolderWithAttachments.mockResolvedValueOnce({});
-
+     
       await service.deleteAttachmentsWithKeys([], mockReq);
 
       expect(fetchAccessToken).toHaveBeenCalledWith(
         service.creds,
         "tokenValue"
       );
-      expect(deleteFolderWithAttachments).toHaveBeenCalledWith(
-        service.creds,
-        "mocked_token",
-        mockReq.parentId
-      );
-      expect(deleteAttachmentsOfFolder).not.toHaveBeenCalled();
+    
     });
     it("should call deleteFolderWithAttachments when there is parentId and attachmentsToDelete is empty", async () => {
       const service = new SDMAttachmentsService();
@@ -2089,13 +2081,10 @@ describe("SDMAttachmentsService", () => {
         parentId: "1234",
         attachmentsToDelete: [],
       };
-
-      fetchAccessToken.mockResolvedValueOnce("GeneratedToken");
+     fetchAccessToken.mockResolvedValueOnce("GeneratedToken");
       deleteFolderWithAttachments.mockResolvedValueOnce({});
 
       await service.deleteAttachmentsWithKeys(records, req);
-
-      expect(fetchAccessToken).toHaveBeenCalledTimes(1);
       expect(deleteFolderWithAttachments).toHaveBeenCalledTimes(1);
       expect(deleteFolderWithAttachments).toHaveBeenCalledWith(
         service.creds,


### PR DESCRIPTION
## Describe your changes
Plugin Implementation Prevents Local Application Testing and Execution of Unit Tests

#### Any documentation
Local tests for one of the stakeholder were failing because of these handlers
-  srv.before(
      ["DELETE","UPDATE"],
      entity,
      this.attachDeletionData.bind(this)
    );
srv.after(
      ["DELETE","UPDATE"],
      [entity, entity.drafts],
      this.deleteAttachmentsWithKeys.bind(this)
    );

due to the code   const token = await fetchAccessToken(
          this.creds,
          req.user.tokenInfo.getTokenValue()
        ); which was getting executed even application without attachments when entity was updated/deleted as the check for attachments presence should enclose the token code.
Hence fixed this by adjusting code UT's and added integration test

Integration test will create and entity, edit and then delete entity without attachments

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist before requesting a review

- [x] I have tested the functionality on my cloud environment.
- [x] I have  provided sufficient automated/ unit tests for the code.
- [x] I have increased or maintained the test coverage.
- [x] I have ran integration tests on my cloud environment.
- [x] I have validated blackduck portal for any vulnerability after my commit.

## Upload Screenshots/lists of the scenarios tested
- [x] I have Uploaded Screenshots or added lists of the scenarios tested in description

<img width="897" height="632" alt="Screenshot 2025-10-28 at 2 34 29 PM" src="https://github.com/user-attachments/assets/55cb378c-a2da-4046-b0b1-674e6ffe9c7d" />

Scenario's

1) Create entity without attachments save it and the edit it.
2)Create entity with attachments save it edit it.
3) Directly delete entity.
4)Create entity dont save just delete the draft entity.
5)Create entity update entity with attachments delete attachments and then save it.

