### PR TITLE
[Fixed]: Tenant Update during Subscription

### DIFF
--- a/lib/mtx/server.js
+++ b/lib/mtx/server.js
@@ -4,6 +4,7 @@ const axios = require('axios');
 const path = require('path');
 const requests = xssec.v3.requests;
 const { getConfigurations } = require("../util/index");
+const { skippingOnboarding } = require("../util/messageConsts");
 const profile = cds.env.profile;
 let configPath;
 
@@ -48,19 +49,38 @@ if (profile === "mtx-sidecar") {
 
     // === Helper to POST the repository object to SDM ===
     const onboardRepository = async (sdmUrl, repositoryObject, token) => {
-    const url = `${sdmUrl}${repositoryUrl}`;
-    const headers = {
-        'Content-Type': 'application/json',
-        'Authorization': `Bearer ${token}`,
+        const url = `${sdmUrl}${repositoryUrl}`;
+        const headers = {
+            'Content-Type': 'application/json',
+            'Authorization': `Bearer ${token}`,
+        };
+
+        try {
+            const response = await axios.post(url, repositoryObject, { headers });
+            return response.data;
+        } catch (error) {
+            const status = error?.response?.status;
+            const data = error?.response?.data;
+
+            // Extract IDs for clarity
+            const repo = repositoryObject.repository || {};
+            const externalId = repo.externalId;
+            const displayName = repo.displayName || repo.name || 'Repository';
+
+            // === Handle "already exists" (409 Conflict) ===
+            if (status === 409) {
+                const messageString = typeof data === 'string' ? data : JSON.stringify(data);
+                if (messageString.includes(`${externalId} already exists`) || messageString.includes('already exists')) {
+                    console.info(skippingOnboarding(displayName, externalId));
+                    return { skipped: true, message: skippingOnboarding(displayName, externalId) };
+                }
+            }
+
+            // === For any other error, rethrow ===
+            throw data || error;
+        }
     };
 
-    try {
-        const response = await axios.post(url, repositoryObject, { headers });
-        return response.data;
-    } catch (error) {
-        throw error?.response?.data || error;
-    }
-    };
 
     // === Helper to GET a list of repositories ===
     const listRepositories = async (sdmUrl, token) => {

--- a/lib/util/messageConsts.js
+++ b/lib/util/messageConsts.js
@@ -1,5 +1,9 @@
 module.exports.duplicateDraftFileErr = (duplicateDraftFiles) =>
   `The file(s) ${duplicateDraftFiles} have been added multiple times. Please rename and try again.`;
+
+module.exports.skippingOnboarding = (repositoryName, repositoryId) =>
+  `Repository with name ${repositoryName} and id ${repositoryId} already exists. Skipping onboarding.`;
+
 module.exports.virusFileErr = (virusFiles) => {
   const bulletPoints = virusFiles.map(file => `• ${file}`).join('\n');
   return `The following files contain potential malware and cannot be uploaded:\n${bulletPoints}\n`;

--- a/test/lib/mtx/server.test.js
+++ b/test/lib/mtx/server.test.js
@@ -15,6 +15,7 @@ describe('SDM Plugin Onboarding and Offboarding Logic', () => {
         jest.resetModules();
         consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
         consoleLogSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+
         const MOCK_CONFIG = { sdm: { repositoryConfig: { description: "A test repository" } } };
         const MOCK_CDS_ROOT = path.resolve(__dirname, '../../..');
         const MOCK_CONFIG_PATH = path.join(MOCK_CDS_ROOT, 'SDMRepositoryConfig.js');
@@ -79,10 +80,44 @@ describe('SDM Plugin Onboarding and Offboarding Logic', () => {
         });
 
         describe('Onboarding Logic', () => {
+            // --- NEW: consoleInfoSpy declared in this specific scope ---
+            let consoleInfoSpy;
+
+            beforeEach(() => {
+                // --- NEW: consoleInfoSpy spied on in this specific beforeEach ---
+                consoleInfoSpy = jest.spyOn(console, 'info').mockImplementation(() => { });
+            });
+
+            afterEach(() => {
+                // --- NEW: consoleInfoSpy restored in this specific afterEach ---
+                consoleInfoSpy.mockRestore();
+            });
+
             it('should successfully onboard a tenant repository on subscribe', async () => {
                 const req = { data: { tenant: 't1', metadata: { subscribedSubdomain: 'tenant-a-subdomain' } } };
                 await subscribeCallback({}, req);
                 expect(axios.post).toHaveBeenCalled();
+            });
+
+            it('should skip onboarding successfully if 409 Conflict indicates repository already exists', async () => {
+                // Arrange: Mock axios to return 409 with an "already exists" message
+                axios.post.mockRejectedValue({
+                    response: {
+                        status: 409,
+                        // This data string triggers the uncovered 'already exists' path
+                        data: `Repository '${MOCK_EXTERNAL_ID}' already exists`
+                    }
+                });
+
+                const req = { data: { tenant: 't_skip', metadata: { subscribedSubdomain: 'tenant-skip-subdomain' } } };
+
+                // Act & Assert: The key assertion is that it should NOT throw/reject
+                await expect(subscribeCallback({}, req)).resolves.not.toThrow();
+
+                // --- FIX: Updated the expected string to match the actual log output ---
+                const expectedLogMessage = `Repository with name Repository and id ${MOCK_EXTERNAL_ID} already exists. Skipping onboarding.`;
+                // consoleInfoSpy is now guaranteed to be defined here
+                expect(consoleInfoSpy).toHaveBeenCalledWith(expectedLogMessage);
             });
 
             it('should throw if buildRepositoryObject fails', async () => {


### PR DESCRIPTION
## Describe your changes

Fixed the tenant subscription issue during onboarding or update scenario -> https://github.com/cap-js/sdm/issues/185
So the issue was while performing update of a tenant the onboarding was getting failed. Since, the Repository is already onboarded with same external ID, we need to skip the onboarding process.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist before requesting a review

- [X] I have tested the functionality on my cloud environment.
- [X] I have  provided sufficient automated/ unit tests for the code.
- [X] I have increased or maintained the test coverage.
- [X] I have ran integration tests on my cloud environment.
- [X] I have validated blackduck portal for any vulnerability after my commit.

## Upload Screenshots/lists of the scenarios tested
- [X] I have Uploaded Screenshots or added lists of the scenarios tested in description
<img width="1073" height="817" alt="Screenshot 2025-10-28 at 2 48 26 PM" src="https://github.com/user-attachments/assets/0ee82127-37dd-4408-b314-749d74865ddc" />


