### PR TITLE
SDMEXT-2459

### DIFF
--- a/lib/sdm.js
+++ b/lib/sdm.js
@@ -128,9 +128,41 @@ module.exports = class SDMAttachmentsService extends (
   }
 
 
+  getAttachmentCompositions(targetEntity) {
+    const attachmentCompositions = [];
+    const entityDef = cds.model.definitions[targetEntity.name];
+    
+    if (!entityDef || !entityDef.elements) {
+      return attachmentCompositions;
+    }
+
+    for (const [elementName, element] of Object.entries(entityDef.elements)) {
+      if (element.type === 'cds.Composition' && element.target) {
+        const targetDef = cds.model.definitions[element.target];
+        if (targetDef && targetDef.includes && targetDef.includes.includes('sap.attachments.Attachments')) {
+          attachmentCompositions.push(elementName);
+        }
+      }
+    }
+    
+    return attachmentCompositions;
+  }
+
   async renameHandler(req) {
     const { repositoryId } = getConfigurations();
-    const attachmentsEntity = cds.model.definitions[req.target.name + ".attachments"];
+    const attachmentCompositions = this.getAttachmentCompositions(req.target);
+    
+    for (const composition of attachmentCompositions) {
+      await this.processCompositionRename(req, composition, repositoryId);
+    }
+  }
+
+  async processCompositionRename(req, compositionName, repositoryId) {
+    const attachmentsEntity = cds.model.definitions[req.target.name + "." + compositionName];
+    if (!attachmentsEntity) {
+      return;
+    }
+    
     const attachment_val = await getDraftAttachments(attachmentsEntity, req, repositoryId);
 
     if (attachment_val.length > 0) {
@@ -156,13 +188,13 @@ module.exports = class SDMAttachmentsService extends (
 
       // Updating draft attachments
       for (const attachment of draft_attachments) {
-        const errorResponse = await this.updateDraftAttachments(req, token, attachment, attachmentsEntity, secondaryPropertiesWithInvalidDefinitions, secondaryTypeProperties);
+        const errorResponse = await this.updateDraftAttachments(req, token, attachment, attachmentsEntity, secondaryPropertiesWithInvalidDefinitions, secondaryTypeProperties, compositionName);
         allErrors = allErrors.concat(errorResponse);
       }
 
       // Updating non-draft attachments
       for (const attachment of attachment_val_rename) {
-        const errorResponse = await this.updateNonDraftAttachments(req, token, attachment, attachmentsEntity, secondaryPropertiesWithInvalidDefinitions, secondaryTypeProperties);
+        const errorResponse = await this.updateNonDraftAttachments(req, token, attachment, attachmentsEntity, secondaryPropertiesWithInvalidDefinitions, secondaryTypeProperties, compositionName);
         allErrors = allErrors.concat(errorResponse);
       }
 
@@ -175,7 +207,7 @@ module.exports = class SDMAttachmentsService extends (
     }
   }
 
-  async updateDraftAttachments(req, token, attachment, attachmentsEntity, secondaryPropertiesWithInvalidDefinitions, secondaryTypeProperties) {
+  async updateDraftAttachments(req, token, attachment, attachmentsEntity, secondaryPropertiesWithInvalidDefinitions, secondaryTypeProperties, compositionName) {
     const attachmentData = await this.getAttachementDataInSDM(this.creds.uri, token, attachment.url);
     const filenameInSDM = attachmentData.filename;
     return this._updateAttachments(
@@ -185,11 +217,12 @@ module.exports = class SDMAttachmentsService extends (
       attachmentsEntity,
       secondaryPropertiesWithInvalidDefinitions,
       secondaryTypeProperties,
-      filenameInSDM
+      filenameInSDM,
+      compositionName
     );
   }
 
-  async updateNonDraftAttachments(req, token, attachment, attachmentsEntity, secondaryPropertiesWithInvalidDefinitions, secondaryTypeProperties) {
+  async updateNonDraftAttachments(req, token, attachment, attachmentsEntity, secondaryPropertiesWithInvalidDefinitions, secondaryTypeProperties, compositionName) {
     const fileNameInDB = await getFileNameForAttachmentID(attachmentsEntity, attachment.ID);
     return this._updateAttachments(
       req,
@@ -198,11 +231,12 @@ module.exports = class SDMAttachmentsService extends (
       attachmentsEntity,
       secondaryPropertiesWithInvalidDefinitions,
       secondaryTypeProperties,
-      fileNameInDB
+      fileNameInDB,
+      compositionName
     );
   }
 
-  async _updateAttachments(req, token, attachment, attachmentsEntity, secondaryPropertiesWithInvalidDefinitions, secondaryTypeProperties, filenameInSDM) {
+  async _updateAttachments(req, token, attachment, attachmentsEntity, secondaryPropertiesWithInvalidDefinitions, secondaryTypeProperties, filenameInSDM, compositionName) {
     let failedReq = [];
     const propertiesInDB = await getPropertiesForID(attachmentsEntity, attachment.ID, secondaryTypeProperties);
     const updatedSecondaryProperties = getUpdatedSecondaryProperties(attachment, secondaryTypeProperties, propertiesInDB);
@@ -210,13 +244,13 @@ module.exports = class SDMAttachmentsService extends (
 
     if (isRestrictedCharactersInName(filenameInRequest)) {
       failedReq.push({ typeOfError: 'restricted characters', name: filenameInRequest });
-      this.replacePropertiesInAttachment(req, attachment.ID, filenameInSDM, propertiesInDB, secondaryTypeProperties);
+      this.replacePropertiesInAttachment(req, attachment.ID, filenameInSDM, propertiesInDB, secondaryTypeProperties, compositionName);
       return failedReq;
     }
 
     if (filenameInRequest == null || filenameInRequest.trim().length === 0) {
       failedReq.push({ typeOfError: 'empty name', name: filenameInRequest });
-      this.replacePropertiesInAttachment(req, attachment.ID, filenameInSDM, propertiesInDB, secondaryTypeProperties);
+      this.replacePropertiesInAttachment(req, attachment.ID, filenameInSDM, propertiesInDB, secondaryTypeProperties, compositionName);
       return failedReq;
     } else if (filenameInSDM !== filenameInRequest) {
       updatedSecondaryProperties["cmis:name"] = filenameInRequest;
@@ -229,17 +263,17 @@ module.exports = class SDMAttachmentsService extends (
         switch (responseCode) {
           case 403:
             failedReq.push({ typeOfError: 'no sdm roles', name: filenameInRequest });
-            this.replacePropertiesInAttachment(req, attachment.ID, filenameInSDM, propertiesInDB, secondaryTypeProperties);
+            this.replacePropertiesInAttachment(req, attachment.ID, filenameInSDM, propertiesInDB, secondaryTypeProperties, compositionName);
             break;
 
           case 409:
             failedReq.push({ typeOfError: 'duplicate', name: filenameInRequest });
-            this.replacePropertiesInAttachment(req, attachment.ID, filenameInSDM, propertiesInDB, secondaryTypeProperties);
+            this.replacePropertiesInAttachment(req, attachment.ID, filenameInSDM, propertiesInDB, secondaryTypeProperties, compositionName);
             break;
 
           case 404:
             failedReq.push({ typeOfError: 'not found', name: filenameInRequest });
-            this.replacePropertiesInAttachment(req, attachment.ID, filenameInSDM, propertiesInDB, secondaryTypeProperties);
+            this.replacePropertiesInAttachment(req, attachment.ID, filenameInSDM, propertiesInDB, secondaryTypeProperties, compositionName);
             break;
 
           case 200:
@@ -254,10 +288,10 @@ module.exports = class SDMAttachmentsService extends (
         if (e.message.startsWith(unsupportedProperties)) {
           const unsupportedDetails = e.message.substring(unsupportedProperties.length).trim();
           failedReq.push({ typeOfError: 'unsupported properties', details: unsupportedDetails });
-          this.replacePropertiesInAttachment(req, attachment.ID, filenameInSDM, propertiesInDB, secondaryTypeProperties);
+          this.replacePropertiesInAttachment(req, attachment.ID, filenameInSDM, propertiesInDB, secondaryTypeProperties, compositionName);
         } else {
           failedReq.push({ typeOfError: 'bad request', name: filenameInRequest, message: e.message });
-          this.replacePropertiesInAttachment(req, attachment.ID, filenameInSDM, propertiesInDB, secondaryTypeProperties);
+          this.replacePropertiesInAttachment(req, attachment.ID, filenameInSDM, propertiesInDB, secondaryTypeProperties, compositionName);
         }
       }
     }
@@ -265,8 +299,12 @@ module.exports = class SDMAttachmentsService extends (
     return failedReq;
   }
 
-  replacePropertiesInAttachment(req, id, fileName, propertiesInDB, secondaryTypeProperties) {
-    const attachment = req.data.attachments.find(element => element.ID === id);
+  replacePropertiesInAttachment(req, id, fileName, propertiesInDB, secondaryTypeProperties, compositionName) {
+    if (!req.data[compositionName]) {
+      return;
+    }
+    
+    const attachment = req.data[compositionName].find(element => element.ID === id);
     if (!attachment) {
       return;
     }
@@ -542,29 +580,77 @@ module.exports = class SDMAttachmentsService extends (
   }
 
   async attachDeletionData(req) {
-    const attachments =
-      cds.model.definitions[req.target.name + ".attachments"];
-    if (attachments) {
-      const diffData = await req.diff();
-      let deletedAttachments = [];
-     if (diffData?.attachments?.length > 0) {
-        diffData.attachments
-          .filter((object) => {
-            return object._op === "delete";
-          })
-          .map((attachment) => {
-            deletedAttachments.push(attachment.ID);
-          });
-        if (deletedAttachments.length > 0) {
-          const attachmentsToDelete = await getURLsToDeleteFromAttachments(
-            deletedAttachments,
-            attachments
-          );
-          if (attachmentsToDelete.length > 0) {
-            req.attachmentsToDelete = attachmentsToDelete;
+    const attachmentCompositions = this.getAttachmentCompositions(req.target);
+    
+    for (const compositionName of attachmentCompositions) {
+      const attachments = cds.model.definitions[req.target.name + "." + compositionName];
+      if (attachments) {
+        const diffData = await req.diff();
+        let deletedAttachments = [];
+       if (diffData?.[compositionName]?.length > 0) {
+          diffData[compositionName]
+            .filter((object) => {
+              return object._op === "delete";
+            })
+            .map((attachment) => {
+              deletedAttachments.push(attachment.ID);
+            });
+          if (deletedAttachments.length > 0) {
+            const attachmentsToDelete = await getURLsToDeleteFromAttachments(
+              deletedAttachments,
+              attachments
+            );
+            if (attachmentsToDelete.length > 0) {
+              if (!req.attachmentsToDelete) {
+                req.attachmentsToDelete = [];
+              }
+              req.attachmentsToDelete.push(...attachmentsToDelete);
+            }
+          }
+          if (req.event == "DELETE") {
+            const token = await fetchAccessToken(
+              this.creds,
+              req.user.tokenInfo.getTokenValue()
+            );
+            const folderId = await getFolderIdByIDAsPath(
+              req,
+              this.creds,
+              token,
+              attachments
+            );
+            if (folderId) {
+              if (!req.parentId) {
+                req.parentId = [];
+              }
+              req.parentId.push(folderId);
+            }
           }
         }
-        if (req.event == "DELETE") {
+      }
+    }
+  }
+
+  async attachDraftDeletionData(req) {
+    const baseEntityName = req.target.name.replace(/\.drafts$/, "");
+    const baseEntity = cds.model.definitions[baseEntityName];
+    if (!baseEntity) {
+      return;
+    }
+    
+    const attachmentCompositions = this.getAttachmentCompositions({ name: baseEntityName });
+    
+    for (const compositionName of attachmentCompositions) {
+      let draftAttachments = cds.model.definitions[baseEntityName + "." + compositionName + ".drafts"];
+      if(draftAttachments)  {
+        const attachmentsToDeleteFromDraft = await getURLsToDeleteFromDraftAttachments(req.data.ID, draftAttachments);
+        if (attachmentsToDeleteFromDraft?.length > 0) {
+          if (!req.attachmentsToDelete) {
+            req.attachmentsToDelete = [];
+          }
+          req.attachmentsToDelete.push(...attachmentsToDeleteFromDraft);
+        }
+        const diffData = await req.diff();
+        if (req.event == "DELETE" && diffData[compositionName]?.length == attachmentsToDeleteFromDraft?.length) {
           const token = await fetchAccessToken(
             this.creds,
             req.user.tokenInfo.getTokenValue()
@@ -573,37 +659,14 @@ module.exports = class SDMAttachmentsService extends (
             req,
             this.creds,
             token,
-            attachments
+            draftAttachments
           );
           if (folderId) {
-            req.parentId = folderId;
+            if (!req.parentId) {
+              req.parentId = [];
+            }
+            req.parentId.push(folderId);
           }
-        }
-      }
-    }
-  }
-
-  async attachDraftDeletionData(req) {
-    let draftAttachments = cds.model.definitions[req.target.name.replace(/\.drafts$/, ".attachments.drafts")];
-    if(draftAttachments)  {
-      const attachmentsToDeleteFromDraft = await getURLsToDeleteFromDraftAttachments(req.data.ID, draftAttachments);
-      if (attachmentsToDeleteFromDraft?.length > 0) {
-        req.attachmentsToDelete = attachmentsToDeleteFromDraft;
-      }
-      const diffData = await req.diff();
-      if (req.event == "DELETE" && diffData.attachments?.length == req.attachmentsToDelete?.length) {
-        const token = await fetchAccessToken(
-          this.creds,
-          req.user.tokenInfo.getTokenValue()
-        );
-        const folderId = await getFolderIdByIDAsPath(
-          req,
-          this.creds,
-          token,
-          draftAttachments
-        );
-        if (folderId) {
-          req.parentId = folderId;
         }
       }
     }
@@ -631,7 +694,11 @@ module.exports = class SDMAttachmentsService extends (
           req.user.tokenInfo.getTokenValue()
         );
        if (req?.parentId) {
-        await deleteFolderWithAttachments(this.creds, token, req.parentId);
+        // Handle both single parentId and array of parentIds
+        const parentIds = Array.isArray(req.parentId) ? req.parentId : [req.parentId];
+        for (const parentId of parentIds) {
+          await deleteFolderWithAttachments(this.creds, token, parentId);
+        }
       } else {
         const deletePromises = req.attachmentsToDelete.map(
           async (attachment) => {
@@ -668,7 +735,11 @@ module.exports = class SDMAttachmentsService extends (
                 this.creds,
                 req.user.tokenInfo.getTokenValue()
               );
-        await deleteFolderWithAttachments(this.creds, token, req.parentId);
+        // Handle both single parentId and array of parentIds
+        const parentIds = Array.isArray(req.parentId) ? req.parentId : [req.parentId];
+        for (const parentId of parentIds) {
+          await deleteFolderWithAttachments(this.creds, token, parentId);
+        }
       }
     }
   }
@@ -917,17 +988,25 @@ if(response.response.data.message == 'Malware Service Exception: Virus found in 
     }
 }
   async handleDraftSaveForLinks(req) {
-    if (!req.target?.name) {
-      const entityPatterns = [
-        'ProcessorService.Incidents.attachments',
-        'ProcessorService.Incidents.attachments.drafts'
-      ];
-      
-      for (const entityName of entityPatterns) {
-        const attachmentsEntity = cds.model.definitions[entityName];
-        if (attachmentsEntity) {
-          await this.updateBaselinesForEntity(entityName);
+    // Find all entities with attachment compositions
+    const allEntities = Object.keys(cds.model.definitions);
+    const entityPatterns = [];
+    
+    for (const entityName of allEntities) {
+      const entity = cds.model.definitions[entityName];
+      if (entity && entity.elements) {
+        const attachmentCompositions = this.getAttachmentCompositions({ name: entityName });
+        for (const composition of attachmentCompositions) {
+          entityPatterns.push(`${entityName}.${composition}`);
+          entityPatterns.push(`${entityName}.${composition}.drafts`);
         }
+      }
+    }
+    
+    for (const entityName of entityPatterns) {
+      const attachmentsEntity = cds.model.definitions[entityName];
+      if (attachmentsEntity) {
+        await this.updateBaselinesForEntity(entityName);
       }
     }
   }
@@ -952,29 +1031,43 @@ if(response.response.data.message == 'Malware Service Exception: Virus found in 
 
   async handleDraftDiscardForLinks(req) {
     let parentId = req.data.ID;
-    const attachmentsEntityName = req.target.name.replace('.drafts', '.attachments.drafts');
-    const attachmentsEntity = cds.model.definitions[attachmentsEntityName];
-    const upKey = attachmentsEntity.keys?.up_?.keys?.[0]?.$generatedFieldName || 'up__ID';
-    const draftAttachments = await global.SELECT.from(attachmentsEntityName)
-      .where({ 
-        [upKey]: parentId,
-        mimeType: "application/internet-shortcut",
-        note: { like: "__BASELINE_URL__:%" }
-      });
-
+    const baseEntityName = req.target.name.replace(/\.drafts$/, "");
+    const baseEntity = cds.model.definitions[baseEntityName];
+    if (!baseEntity) {
+      return;
+    }
+    
+    const attachmentCompositions = this.getAttachmentCompositions({ name: baseEntityName });
+    
     const token = await fetchAccessToken(
       this.creds,
       req.user.authInfo?.token?.getTokenValue() || req.user.tokenInfo.getTokenValue()
     );
 
-    for (const attachment of draftAttachments) {
-      if (attachment.note?.startsWith("__BASELINE_URL__:")) {
-        const baselineUrl = attachment.note.substring("__BASELINE_URL__:".length);
-        
-        if (baselineUrl && attachment.linkUrl !== baselineUrl) {
-          await this.revertLinkInSDM(attachment, baselineUrl, token);
-          const attachmentKey = `${attachment.ID}`;
-          this.originalUrlMap.delete(attachmentKey);
+    for (const compositionName of attachmentCompositions) {
+      const attachmentsEntityName = `${baseEntityName}.${compositionName}.drafts`;
+      const attachmentsEntity = cds.model.definitions[attachmentsEntityName];
+      if (!attachmentsEntity) {
+        continue;
+      }
+      
+      const upKey = attachmentsEntity.keys?.up_?.keys?.[0]?.$generatedFieldName || 'up__ID';
+      const draftAttachments = await global.SELECT.from(attachmentsEntityName)
+        .where({ 
+          [upKey]: parentId,
+          mimeType: "application/internet-shortcut",
+          note: { like: "__BASELINE_URL__:%" }
+        });
+
+      for (const attachment of draftAttachments) {
+        if (attachment.note?.startsWith("__BASELINE_URL__:")) {
+          const baselineUrl = attachment.note.substring("__BASELINE_URL__:".length);
+          
+          if (baselineUrl && attachment.linkUrl !== baselineUrl) {
+            await this.revertLinkInSDM(attachment, baselineUrl, token);
+            const attachmentKey = `${attachment.ID}`;
+            this.originalUrlMap.delete(attachmentKey);
+          }
         }
       }
     }

--- a/lib/sdm.js
+++ b/lib/sdm.js
@@ -210,93 +210,106 @@ module.exports = class SDMAttachmentsService extends (
   async updateDraftAttachments(req, token, attachment, attachmentsEntity, secondaryPropertiesWithInvalidDefinitions, secondaryTypeProperties, compositionName) {
     const attachmentData = await this.getAttachementDataInSDM(this.creds.uri, token, attachment.url);
     const filenameInSDM = attachmentData.filename;
-    return this._updateAttachments(
-      req,
-      token,
+    
+    const context = {
       attachment,
       attachmentsEntity,
-      secondaryPropertiesWithInvalidDefinitions,
-      secondaryTypeProperties,
       filenameInSDM,
-      compositionName
-    );
+      compositionName,
+      secondaryProperties: {
+        invalidDefinitions: secondaryPropertiesWithInvalidDefinitions,
+        typeProperties: secondaryTypeProperties
+      }
+    };
+    
+    return this._updateAttachments(req, token, context);
   }
 
   async updateNonDraftAttachments(req, token, attachment, attachmentsEntity, secondaryPropertiesWithInvalidDefinitions, secondaryTypeProperties, compositionName) {
     const fileNameInDB = await getFileNameForAttachmentID(attachmentsEntity, attachment.ID);
-    return this._updateAttachments(
-      req,
-      token,
+    
+    const context = {
       attachment,
       attachmentsEntity,
-      secondaryPropertiesWithInvalidDefinitions,
-      secondaryTypeProperties,
-      fileNameInDB,
-      compositionName
-    );
+      filenameInSDM: fileNameInDB,
+      compositionName,
+      secondaryProperties: {
+        invalidDefinitions: secondaryPropertiesWithInvalidDefinitions,
+        typeProperties: secondaryTypeProperties
+      }
+    };
+    
+    return this._updateAttachments(req, token, context);
   }
 
-  async _updateAttachments(req, token, attachment, attachmentsEntity, secondaryPropertiesWithInvalidDefinitions, secondaryTypeProperties, filenameInSDM, compositionName) {
+  async _updateAttachments(req, token, context) {
+    const { attachment, attachmentsEntity, filenameInSDM, compositionName, secondaryProperties } = context;
+    const { invalidDefinitions, typeProperties } = secondaryProperties;
+    
     let failedReq = [];
-    const propertiesInDB = await getPropertiesForID(attachmentsEntity, attachment.ID, secondaryTypeProperties);
-    const updatedSecondaryProperties = getUpdatedSecondaryProperties(attachment, secondaryTypeProperties, propertiesInDB);
+    const propertiesInDB = await getPropertiesForID(attachmentsEntity, attachment.ID, typeProperties);
+    const updatedSecondaryProperties = getUpdatedSecondaryProperties(attachment, typeProperties, propertiesInDB);
     const filenameInRequest = attachment.filename;
 
-    if (isRestrictedCharactersInName(filenameInRequest)) {
-      failedReq.push({ typeOfError: 'restricted characters', name: filenameInRequest });
-      this.replacePropertiesInAttachment(req, attachment.ID, filenameInSDM, propertiesInDB, secondaryTypeProperties, compositionName);
+    const validationError = this.validateFilename(filenameInRequest);
+    if (validationError) {
+      failedReq.push(validationError);
+      this.replacePropertiesInAttachment(req, attachment.ID, filenameInSDM, propertiesInDB, typeProperties, compositionName);
       return failedReq;
     }
 
-    if (filenameInRequest == null || filenameInRequest.trim().length === 0) {
-      failedReq.push({ typeOfError: 'empty name', name: filenameInRequest });
-      this.replacePropertiesInAttachment(req, attachment.ID, filenameInSDM, propertiesInDB, secondaryTypeProperties, compositionName);
-      return failedReq;
-    } else if (filenameInSDM !== filenameInRequest) {
+    if (filenameInSDM !== filenameInRequest) {
       updatedSecondaryProperties["cmis:name"] = filenameInRequest;
     }
 
     if (Object.keys(updatedSecondaryProperties).length > 0) {
-      try {
-        const responseCode = await updateAttachment(req, attachment, this.creds, token, updatedSecondaryProperties, secondaryPropertiesWithInvalidDefinitions);
-
-        switch (responseCode) {
-          case 403:
-            failedReq.push({ typeOfError: 'no sdm roles', name: filenameInRequest });
-            this.replacePropertiesInAttachment(req, attachment.ID, filenameInSDM, propertiesInDB, secondaryTypeProperties, compositionName);
-            break;
-
-          case 409:
-            failedReq.push({ typeOfError: 'duplicate', name: filenameInRequest });
-            this.replacePropertiesInAttachment(req, attachment.ID, filenameInSDM, propertiesInDB, secondaryTypeProperties, compositionName);
-            break;
-
-          case 404:
-            failedReq.push({ typeOfError: 'not found', name: filenameInRequest });
-            this.replacePropertiesInAttachment(req, attachment.ID, filenameInSDM, propertiesInDB, secondaryTypeProperties, compositionName);
-            break;
-
-          case 200:
-          case 201:
-            // Success cases, do nothing
-            break;
-
-          default:
-            throw new Error(sdmRolesErrorMessage);
-        }
-      } catch (e) {
-        if (e.message.startsWith(unsupportedProperties)) {
-          const unsupportedDetails = e.message.substring(unsupportedProperties.length).trim();
-          failedReq.push({ typeOfError: 'unsupported properties', details: unsupportedDetails });
-          this.replacePropertiesInAttachment(req, attachment.ID, filenameInSDM, propertiesInDB, secondaryTypeProperties, compositionName);
-        } else {
-          failedReq.push({ typeOfError: 'bad request', name: filenameInRequest, message: e.message });
-          this.replacePropertiesInAttachment(req, attachment.ID, filenameInSDM, propertiesInDB, secondaryTypeProperties, compositionName);
-        }
+      const updateResult = await this.performAttachmentUpdate(
+        req, token, attachment, updatedSecondaryProperties, invalidDefinitions, filenameInRequest
+      );
+      
+      if (updateResult.error) {
+        failedReq.push(updateResult.error);
+        this.replacePropertiesInAttachment(req, attachment.ID, filenameInSDM, propertiesInDB, typeProperties, compositionName);
       }
     }
 
     return failedReq;
+  }
+
+  validateFilename(filename) {
+    if (isRestrictedCharactersInName(filename)) {
+      return { typeOfError: 'restricted characters', name: filename };
+    }
+    if (filename == null || filename.trim().length === 0) {
+      return { typeOfError: 'empty name', name: filename };
+    }
+    return null;
+  }
+
+  async performAttachmentUpdate(req, token, attachment, updatedSecondaryProperties, invalidDefinitions, filenameInRequest) {
+    try {
+      const responseCode = await updateAttachment(req, attachment, this.creds, token, updatedSecondaryProperties, invalidDefinitions);
+
+      switch (responseCode) {
+        case 403:
+          return { error: { typeOfError: 'no sdm roles', name: filenameInRequest } };
+        case 409:
+          return { error: { typeOfError: 'duplicate', name: filenameInRequest } };
+        case 404:
+          return { error: { typeOfError: 'not found', name: filenameInRequest } };
+        case 200:
+        case 201:
+          return { success: true };
+        default:
+          throw new Error(sdmRolesErrorMessage);
+      }
+    } catch (e) {
+      if (e.message.startsWith(unsupportedProperties)) {
+        const unsupportedDetails = e.message.substring(unsupportedProperties.length).trim();
+        return { error: { typeOfError: 'unsupported properties', details: unsupportedDetails } };
+      }
+      return { error: { typeOfError: 'bad request', name: filenameInRequest, message: e.message } };
+    }
   }
 
   replacePropertiesInAttachment(req, id, fileName, propertiesInDB, secondaryTypeProperties, compositionName) {
@@ -586,47 +599,64 @@ module.exports = class SDMAttachmentsService extends (
       const attachments = cds.model.definitions[req.target.name + "." + compositionName];
       if (attachments) {
         const diffData = await req.diff();
-        let deletedAttachments = [];
-       if (diffData?.[compositionName]?.length > 0) {
-          diffData[compositionName]
-            .filter((object) => {
-              return object._op === "delete";
-            })
-            .map((attachment) => {
-              deletedAttachments.push(attachment.ID);
-            });
-          if (deletedAttachments.length > 0) {
-            const attachmentsToDelete = await getURLsToDeleteFromAttachments(
-              deletedAttachments,
-              attachments
-            );
-            if (attachmentsToDelete.length > 0) {
-              if (!req.attachmentsToDelete) {
-                req.attachmentsToDelete = [];
-              }
-              req.attachmentsToDelete.push(...attachmentsToDelete);
-            }
-          }
-          if (req.event == "DELETE") {
-            const token = await fetchAccessToken(
-              this.creds,
-              req.user.tokenInfo.getTokenValue()
-            );
-            const folderId = await getFolderIdByIDAsPath(
-              req,
-              this.creds,
-              token,
-              attachments
-            );
-            if (folderId) {
-              if (!req.parentId) {
-                req.parentId = [];
-              }
-              req.parentId.push(folderId);
-            }
-          }
-        }
+        await this.processAttachmentDeletion(req, diffData, compositionName, attachments);
       }
+    }
+  }
+
+  async processAttachmentDeletion(req, diffData, compositionName, attachments) {
+    if (!diffData?.[compositionName]?.length) {
+      return;
+    }
+
+    const deletedAttachments = this.extractDeletedAttachmentIds(diffData[compositionName]);
+    
+    if (deletedAttachments.length > 0) {
+      await this.addAttachmentsToDeleteList(req, deletedAttachments, attachments);
+    }
+    
+    if (req.event === "DELETE") {
+      await this.addFolderToParentIdList(req, attachments);
+    }
+  }
+
+  extractDeletedAttachmentIds(compositionData) {
+    return compositionData
+      .filter((object) => object._op === "delete")
+      .map((attachment) => attachment.ID);
+  }
+
+  async addAttachmentsToDeleteList(req, deletedAttachments, attachments) {
+    const attachmentsToDelete = await getURLsToDeleteFromAttachments(
+      deletedAttachments,
+      attachments
+    );
+    
+    if (attachmentsToDelete.length > 0) {
+      if (!req.attachmentsToDelete) {
+        req.attachmentsToDelete = [];
+      }
+      req.attachmentsToDelete.push(...attachmentsToDelete);
+    }
+  }
+
+  async addFolderToParentIdList(req, attachments) {
+    const token = await fetchAccessToken(
+      this.creds,
+      req.user.tokenInfo.getTokenValue()
+    );
+    const folderId = await getFolderIdByIDAsPath(
+      req,
+      this.creds,
+      token,
+      attachments
+    );
+    
+    if (folderId) {
+      if (!req.parentId) {
+        req.parentId = [];
+      }
+      req.parentId.push(folderId);
     }
   }
 

--- a/lib/sdm.js
+++ b/lib/sdm.js
@@ -987,7 +987,7 @@ if(response.response.data.message == 'Malware Service Exception: Virus found in 
       req.reject(response?.response?.data?.message);
     }
 }
-  async handleDraftSaveForLinks(req) {
+  async handleDraftSaveForLinks() {
     // Find all entities with attachment compositions
     const allEntities = Object.keys(cds.model.definitions);
     const entityPatterns = [];

--- a/test/integration/api.js
+++ b/test/integration/api.js
@@ -188,7 +188,7 @@ class Api {
 
         try{
             response = await axios.post(
-                `https://${appUrl}/odata/v4/${serviceName}/${entityName}(ID=${incidentID},IsActiveEntity=false)/attachments`,
+                `https://${appUrl}/odata/v4/${serviceName}/${entityName}(ID=${incidentID},IsActiveEntity=false)/references`,
                 postData,
                 this.config
             )
@@ -199,7 +199,7 @@ class Api {
                 // responseStatus.attachmentID.push(response.data.ID)
                  try{
                     await axios.put(
-                     `https://${appUrl}/odata/v4/${serviceName}/${entityName}(ID=${incidentID},IsActiveEntity=false)/attachments(ID=${response.data.ID},IsActiveEntity=false)/content`,
+                     `https://${appUrl}/odata/v4/${serviceName}/${entityName}(ID=${incidentID},IsActiveEntity=false)/references(ID=${response.data.ID},IsActiveEntity=false)/content`,
 
                     formDataPut,
                     this.config
@@ -243,7 +243,7 @@ class Api {
         try{
             let response;
             response = await axios.get(
-                `https://${appUrl}/odata/v4/${serviceName}/${entityName}(ID=${incidentID},IsActiveEntity=true)/attachments(up__ID=${incidentID},ID=${attachment},IsActiveEntity=true)/content`,
+                `https://${appUrl}/odata/v4/${serviceName}/${entityName}(ID=${incidentID},IsActiveEntity=true)/references(up__ID=${incidentID},ID=${attachment},IsActiveEntity=true)/content`,
                 this.config
             );
             if (response.status === 200 && response.data) {
@@ -269,7 +269,7 @@ class Api {
 
         try {
             response = await axios.get(
-                `https://${appUrl}/odata/v4/${serviceName}/${entityName}(ID=${incidentID},IsActiveEntity=true)/attachments(up__ID=${incidentID},ID=${attachment},IsActiveEntity=true)`,
+                `https://${appUrl}/odata/v4/${serviceName}/${entityName}(ID=${incidentID},IsActiveEntity=true)/references(up__ID=${incidentID},ID=${attachment},IsActiveEntity=true)`,
                 this.config
             );
 
@@ -296,7 +296,7 @@ class Api {
         let response;
          try{
             response = await axios.patch(
-               `https://${appUrl}/odata/v4/${serviceName}/${entityName}(ID=${incidentID},IsActiveEntity=false)/attachments(ID=${attachment},IsActiveEntity=false)`,
+               `https://${appUrl}/odata/v4/${serviceName}/${entityName}(ID=${incidentID},IsActiveEntity=false)/references(ID=${attachment},IsActiveEntity=false)`,
                 updateData,
                 this.config
             );
@@ -322,7 +322,7 @@ class Api {
         let response;
         try{
             response = await axios.delete(
-                 `https://${appUrl}/odata/v4/${serviceName}/${entityName}(ID=${incidentID},IsActiveEntity=false)/attachments(ID=${attachment},IsActiveEntity=false)`,
+                 `https://${appUrl}/odata/v4/${serviceName}/${entityName}(ID=${incidentID},IsActiveEntity=false)/references(ID=${attachment},IsActiveEntity=false)`,
                 this.config
             );
             if (response.status === 204) {
@@ -352,7 +352,7 @@ class Api {
             };
             
             response = await axios.post(
-                `https://${appUrl}/odata/v4/${serviceName}/${entityName}(ID=${incidentID},IsActiveEntity=false)/attachments/${srvpath}.createLink`,
+                `https://${appUrl}/odata/v4/${serviceName}/${entityName}(ID=${incidentID},IsActiveEntity=false)/references/${srvpath}.createLink`,
                 linkData,
                 this.config
             )
@@ -384,7 +384,7 @@ class Api {
         let response;
         try {
             response = await axios.get(
-                `https://${appUrl}/odata/v4/${serviceName}/${entityName}(ID=${incidentID},IsActiveEntity=false)/attachments`,
+                `https://${appUrl}/odata/v4/${serviceName}/${entityName}(ID=${incidentID},IsActiveEntity=false)/references`,
                 this.config
             );
             if (response.status === 200 && response.data && response.data.value) {
@@ -410,7 +410,7 @@ class Api {
         let response;
         try {
             response = await axios.post(
-                `https://${appUrl}/odata/v4/${serviceName}/${entityName}(ID=${incidentID},IsActiveEntity=false)/attachments(ID=${attachment},IsActiveEntity=false)/${srvpath}.openAttachment`,
+                `https://${appUrl}/odata/v4/${serviceName}/${entityName}(ID=${incidentID},IsActiveEntity=false)/references(ID=${attachment},IsActiveEntity=false)/${srvpath}.openAttachment`,
                 {},
                 this.config
             )
@@ -437,7 +437,7 @@ class Api {
         let response;
         try {
             response = await axios.post(
-                `https://${appUrl}/odata/v4/${serviceName}/${entityName}(ID=${incidentID},IsActiveEntity=true)/attachments(ID=${attachment},IsActiveEntity=true)/${srvpath}.openAttachment`,
+                `https://${appUrl}/odata/v4/${serviceName}/${entityName}(ID=${incidentID},IsActiveEntity=true)/references(ID=${attachment},IsActiveEntity=true)/${srvpath}.openAttachment`,
                 {},
                 this.config
             )

--- a/test/lib/sdm.test.js
+++ b/test/lib/sdm.test.js
@@ -557,8 +557,8 @@ describe("SDMAttachmentsService", () => {
       fetchAccessToken.mockResolvedValue(token);
       getDraftAttachments.mockResolvedValue(allAttachments);
       
-      service._updateAttachments = jest.fn((req, token, attachment) => {
-        if (attachment.ID === 'draft1') {
+      service._updateAttachments = jest.fn((req, token, context) => {
+        if (context.attachment.ID === 'draft1') {
           return Promise.reject(new Error('Draft update failed'));
         }
         return [];
@@ -1601,20 +1601,22 @@ describe("SDMAttachmentsService", () => {
     it('should handle _updateAttachments when Object.keys length is 0', async () => {
       const req = { data: { references: [{ ID: '123', filename: 'test.txt' }] } };
       const token = 'test-token';
-      const attachment = { ID: '123', filename: 'test.txt' };
-      const attachmentsEntity = {};
-      const secondaryPropertiesWithInvalidDefinitions = {};
-      const secondaryTypeProperties = new Map();
-      const filenameInSDM = 'test.txt';
+      const context = {
+        attachment: { ID: '123', filename: 'test.txt' },
+        attachmentsEntity: {},
+        filenameInSDM: 'test.txt',
+        compositionName: 'references',
+        secondaryProperties: {
+          invalidDefinitions: {},
+          typeProperties: new Map()
+        }
+      };
 
       // Mock functions to return empty objects
       getPropertiesForID.mockResolvedValue({});
       getUpdatedSecondaryProperties.mockReturnValue({});
 
-      const result = await service._updateAttachments(
-        req, token, attachment, attachmentsEntity, 
-        secondaryPropertiesWithInvalidDefinitions, secondaryTypeProperties, filenameInSDM
-      );
+      const result = await service._updateAttachments(req, token, context);
 
       expect(result).toEqual([]);
       expect(updateAttachment).not.toHaveBeenCalled();
@@ -1724,26 +1726,24 @@ describe("SDMAttachmentsService", () => {
         }
       };
       const token = 'mock-token';
-      const attachment = {
-        ID: 'attachment-123',
-        filename: 'test.txt'
+      const context = {
+        attachment: {
+          ID: 'attachment-123',
+          filename: 'test.txt'
+        },
+        attachmentsEntity: { name: 'TestEntity' },
+        filenameInSDM: 'test.txt',
+        compositionName: 'references',
+        secondaryProperties: {
+          invalidDefinitions: {},
+          typeProperties: new Map()
+        }
       };
-      const attachmentsEntity = { name: 'TestEntity' };
-      const secondaryPropertiesWithInvalidDefinitions = {};
-      const secondaryTypeProperties = new Map();
-      const filenameInSDM = 'test.txt';
 
       getPropertiesForID.mockResolvedValue({});
+      getUpdatedSecondaryProperties.mockReturnValue({});
       
-      const result = await service._updateAttachments(
-        req,
-        token, 
-        attachment,
-        attachmentsEntity,
-        secondaryPropertiesWithInvalidDefinitions,
-        secondaryTypeProperties,
-        filenameInSDM
-      );
+      const result = await service._updateAttachments(req, token, context);
 
       expect(result).toEqual([]);
     });

--- a/test/lib/sdm.test.js
+++ b/test/lib/sdm.test.js
@@ -159,10 +159,49 @@ const mockUpKeyStructure = {
 };
 
 const cds = require("@sap/cds/lib");
-cds.model.definitions['ProcessorService.Incidents.attachments'] = {};
-cds.model.definitions['ProcessorService.Incidents.attachments.drafts'] = mockUpKeyStructure;
-cds.model.definitions['Test.Entity.attachments'] = {}; // Added to satisfy test structure
-cds.model.definitions['Test.Entity.attachments.drafts'] = mockUpKeyStructure; // Added to satisfy test structure
+cds.model.definitions['ProcessorService.Incidents.references'] = {};
+cds.model.definitions['ProcessorService.Incidents.references.drafts'] = mockUpKeyStructure;
+cds.model.definitions['Test.Entity.references'] = {}; // Added to satisfy test structure
+cds.model.definitions['Test.Entity.references.drafts'] = mockUpKeyStructure; // Added to satisfy test structure
+
+// Add entity with 'references' composition for testing alternative composition names
+cds.model.definitions['Test.Entity.references'] = {};
+cds.model.definitions['Test.Entity.references.drafts'] = mockUpKeyStructure;
+cds.model.definitions['Test.EntityWithReferences'] = {
+  elements: {
+    references: {
+      type: 'cds.Composition',
+      target: 'Test.Entity.references'
+    }
+  }
+};
+cds.model.definitions['Test.Entity.references'] = {
+  includes: ['sap.attachments.Attachments']
+};
+cds.model.definitions['ProcessorService.Orders'] = {
+  elements: {
+    references: {
+      type: 'cds.Composition',
+      target: 'ProcessorService.Orders.references'
+    }
+  }
+};
+cds.model.definitions['ProcessorService.Orders.references'] = {
+  includes: ['sap.attachments.Attachments'],
+  keys: {
+    up_: {
+      keys: [{ $generatedFieldName: 'up__ID' }]
+    }
+  }
+};
+cds.model.definitions['ProcessorService.Orders.references.drafts'] = {
+  includes: ['sap.attachments.Attachments'],
+  keys: {
+    up_: {
+      keys: [{ $generatedFieldName: 'up__ID' }]
+    }
+  }
+};
 
 describe("SDMAttachmentsService", () => {
   // Ensure attachmentIDRegex is available globally
@@ -377,7 +416,17 @@ describe("SDMAttachmentsService", () => {
       };
       token = 'sampleAccessToken';
       
-      cds.model.definitions['sampleTarget.attachments'] = {};
+      cds.model.definitions['sampleTarget'] = {
+        elements: {
+          references: {
+            type: 'cds.Composition',
+            target: 'sampleTarget.references'
+          }
+        }
+      };
+      cds.model.definitions['sampleTarget.references'] = {
+        includes: ['sap.attachments.Attachments']
+      };
     });
   
     it('should not rename if no attachments are modified', async () => {
@@ -392,7 +441,7 @@ describe("SDMAttachmentsService", () => {
   
       expect(service.isFileNameDuplicateInDrafts).not.toHaveBeenCalled();
       expect(fetchAccessToken).not.toHaveBeenCalled();
-      expect(getDraftAttachments).toHaveBeenCalledWith(cds.model.definitions['sampleTarget.attachments'], req, 'repo123');
+      expect(getDraftAttachments).toHaveBeenCalledWith(cds.model.definitions['sampleTarget.references'], req, 'repo123');
       expect(service.updateDraftAttachments).not.toHaveBeenCalled();
       expect(service.updateNonDraftAttachments).not.toHaveBeenCalled();
       expect(req.warn).not.toHaveBeenCalled();
@@ -514,6 +563,104 @@ describe("SDMAttachmentsService", () => {
       expect(fetchAccessToken).toHaveBeenCalledWith(service.creds, 'sampleTokenValue');
       expect(service.updateNonDraftAttachments).not.toHaveBeenCalled();
     });
+
+    // Test with "references" composition instead of "attachments"
+    it('should work with references composition instead of attachments', async () => {
+      req.target.name = 'ProcessorService.Orders';
+      const referencesEntity = cds.model.definitions['ProcessorService.Orders.references'];
+      
+      const draftReferences = [
+        { HasActiveEntity: false, ID: 'draft1' }
+      ];
+      const nonDraftReferences = [
+        { HasActiveEntity: true, ID: 'nonDraft1' }
+      ];
+      const allReferences = [...draftReferences, ...nonDraftReferences];
+  
+      service.isFileNameDuplicateInDrafts = jest.fn().mockResolvedValue();
+      service.updateDraftAttachments = jest.fn().mockResolvedValue([]);
+      service.updateNonDraftAttachments = jest.fn().mockResolvedValue([]);
+      service.clearSecondaryPropertiesCache = jest.fn();
+      service.handleWarning = jest.fn().mockReturnValue("");
+  
+      fetchAccessToken.mockResolvedValue(token);
+      getDraftAttachments.mockResolvedValue(allReferences);
+      getPropertyTitles.mockReturnValue(["Title1", "Title2"]);
+      getSecondaryPropertiesWithInvalidDefinition.mockReturnValue({ invalidProperty: "value" });
+      getSecondaryTypeProperties.mockReturnValue(new Map([["property1", "value1"], ["property2", "value2"]]));
+  
+      await service.renameHandler(req);
+  
+      expect(getDraftAttachments).toHaveBeenCalledWith(referencesEntity, req, 'repo123');
+      expect(service.isFileNameDuplicateInDrafts).toHaveBeenCalledWith(allReferences, req);
+      expect(fetchAccessToken).toHaveBeenCalledWith(service.creds, 'sampleTokenValue');
+      expect(service.updateDraftAttachments).toHaveBeenCalledTimes(1);
+      expect(service.updateNonDraftAttachments).toHaveBeenCalledTimes(1);
+      expect(service.clearSecondaryPropertiesCache).toHaveBeenCalledWith('repo123');
+      expect(req.warn).not.toHaveBeenCalled();
+    });
+
+    it('should discover and process all attachment compositions', async () => {
+      // Create an entity with multiple attachment compositions
+      req.target.name = 'Test.EntityWithMultiple';
+      cds.model.definitions['Test.EntityWithMultiple'] = {
+        elements: {
+          references: {
+            type: 'cds.Composition',
+            target: 'Test.EntityWithMultiple.references'
+          },
+          documents: {
+            type: 'cds.Composition',
+            target: 'Test.EntityWithMultiple.documents'
+          },
+          files: {
+            type: 'cds.Composition',
+            target: 'Test.EntityWithMultiple.files'
+          }
+        }
+      };
+      cds.model.definitions['Test.EntityWithMultiple.references'] = {
+        includes: ['sap.attachments.Attachments']
+      };
+      cds.model.definitions['Test.EntityWithMultiple.documents'] = {
+        includes: ['sap.attachments.Attachments']
+      };
+      cds.model.definitions['Test.EntityWithMultiple.files'] = {
+        includes: ['sap.attachments.Attachments']
+      };
+  
+      service.isFileNameDuplicateInDrafts = jest.fn().mockResolvedValue();
+      service.updateDraftAttachments = jest.fn().mockResolvedValue([]);
+      service.updateNonDraftAttachments = jest.fn().mockResolvedValue([]);
+      service.clearSecondaryPropertiesCache = jest.fn();
+      service.handleWarning = jest.fn().mockReturnValue("");
+  
+      fetchAccessToken.mockResolvedValue(token);
+      getDraftAttachments.mockResolvedValue([{ HasActiveEntity: false, ID: 'draft1' }]);
+      getPropertyTitles.mockReturnValue({});
+      getSecondaryPropertiesWithInvalidDefinition.mockReturnValue({});
+      getSecondaryTypeProperties.mockReturnValue(new Map());
+  
+      await service.renameHandler(req);
+  
+      // Should be called 3 times, once for each composition
+      expect(getDraftAttachments).toHaveBeenCalledTimes(3);
+      expect(getDraftAttachments).toHaveBeenCalledWith(
+        cds.model.definitions['Test.EntityWithMultiple.references'], 
+        req, 
+        'repo123'
+      );
+      expect(getDraftAttachments).toHaveBeenCalledWith(
+        cds.model.definitions['Test.EntityWithMultiple.documents'], 
+        req, 
+        'repo123'
+      );
+      expect(getDraftAttachments).toHaveBeenCalledWith(
+        cds.model.definitions['Test.EntityWithMultiple.files'], 
+        req, 
+        'repo123'
+      );
+    });
   });
 
   describe('updateNonDraftAttachments', () => {
@@ -533,7 +680,7 @@ describe("SDMAttachmentsService", () => {
       req = {
         reject: jest.fn(),
         data: {
-          attachments: [{ ID: 'attachment1', filename: 'file1.txt' }]
+          references: [{ ID: 'attachment1', filename: 'file1.txt' }]
         }
       };
       token = 'mockToken';
@@ -560,7 +707,8 @@ describe("SDMAttachmentsService", () => {
         attachment,
         attachmentsEntity,
         secondaryPropertiesWithInvalidDefinitions,
-        secondaryTypeProperties
+        secondaryTypeProperties,
+        'attachments'
       );
   
       expect(result).toEqual([{ typeOfError: 'restricted characters', name: 'file1.txt' }]);
@@ -569,7 +717,8 @@ describe("SDMAttachmentsService", () => {
         'attachment1',
         'file1.txt',
         { property1: 'value1' },
-        secondaryTypeProperties
+        secondaryTypeProperties,
+        'attachments'
       );
     });
   
@@ -582,7 +731,8 @@ describe("SDMAttachmentsService", () => {
         attachment,
         attachmentsEntity,
         secondaryPropertiesWithInvalidDefinitions,
-        secondaryTypeProperties
+        secondaryTypeProperties,
+        'attachments'
       );
       expect(response).toEqual(
         [{typeOfError: 'empty name', name: null}]
@@ -598,7 +748,8 @@ describe("SDMAttachmentsService", () => {
         attachment,
         attachmentsEntity,
         secondaryPropertiesWithInvalidDefinitions,
-        secondaryTypeProperties
+        secondaryTypeProperties,
+        'attachments'
       );
   
       expect(getUpdatedSecondaryProperties).toHaveBeenCalledWith(
@@ -624,7 +775,8 @@ describe("SDMAttachmentsService", () => {
         attachment,
         attachmentsEntity,
         secondaryPropertiesWithInvalidDefinitions,
-        secondaryTypeProperties
+        secondaryTypeProperties,
+        'attachments'
       );
   
       expect(getUpdatedSecondaryProperties).toHaveBeenCalledWith(
@@ -652,7 +804,8 @@ describe("SDMAttachmentsService", () => {
         attachment,
         attachmentsEntity,
         secondaryPropertiesWithInvalidDefinitions,
-        secondaryTypeProperties
+        secondaryTypeProperties,
+        'attachments'
       );
   
       expect(result).toEqual([{ typeOfError: 'no sdm roles', name: 'file1.txt' }]);
@@ -661,7 +814,8 @@ describe("SDMAttachmentsService", () => {
         'attachment1',
         'file1.txt',
         { property1: 'value1' },
-        secondaryTypeProperties
+        secondaryTypeProperties,
+        'attachments'
       );
     });
   
@@ -674,7 +828,8 @@ describe("SDMAttachmentsService", () => {
         attachment,
         attachmentsEntity,
         secondaryPropertiesWithInvalidDefinitions,
-        secondaryTypeProperties
+        secondaryTypeProperties,
+        'attachments'
       );
   
       expect(result).toEqual([{ typeOfError: 'duplicate', name: 'file1.txt' }]);
@@ -683,7 +838,8 @@ describe("SDMAttachmentsService", () => {
         'attachment1',
         'file1.txt',
         { property1: 'value1' },
-        secondaryTypeProperties
+        secondaryTypeProperties,
+        'attachments'
       );
     });
   
@@ -696,7 +852,8 @@ describe("SDMAttachmentsService", () => {
         attachment,
         attachmentsEntity,
         secondaryPropertiesWithInvalidDefinitions,
-        secondaryTypeProperties
+        secondaryTypeProperties,
+        'attachments'
       );
   
       expect(result).toEqual([{ typeOfError: 'not found', name: 'file1.txt' }]);
@@ -705,7 +862,8 @@ describe("SDMAttachmentsService", () => {
         'attachment1',
         'file1.txt',
         { property1: 'value1' },
-        secondaryTypeProperties
+        secondaryTypeProperties,
+        'attachments'
       );
     });
 
@@ -714,7 +872,7 @@ describe("SDMAttachmentsService", () => {
       getFileNameForAttachmentID.mockResolvedValue('file1.txt'); // Simulate fileNameInDB
       getPropertiesForID.mockResolvedValue({ property1: 'value1' }); // Simulate properties from DB
       getUpdatedSecondaryProperties.mockReturnValue({ property1: 'updatedValue1' }); // Simulate updated properties
-      updateAttachment.mockResolvedValue(500); // Simulate an unexpected response code
+      updateAttachment.mockRejectedValue(new Error(sdmRolesErrorMessage)); // Simulate an unexpected response code
     
       // Call the method
       const result = await service.updateNonDraftAttachments(
@@ -723,7 +881,8 @@ describe("SDMAttachmentsService", () => {
         attachment,
         attachmentsEntity,
         secondaryPropertiesWithInvalidDefinitions,
-        secondaryTypeProperties
+        secondaryTypeProperties,
+        'attachments'
       );
     
       // Verify the result contains the error for the unexpected response code
@@ -741,7 +900,8 @@ describe("SDMAttachmentsService", () => {
         'attachment1',
         'file1.txt',
         { property1: 'value1' },
-        secondaryTypeProperties
+        secondaryTypeProperties,
+        'attachments'
       );
     
       // Ensure updateAttachment was called with the correct arguments
@@ -763,7 +923,8 @@ describe("SDMAttachmentsService", () => {
         attachment,
         attachmentsEntity,
         secondaryPropertiesWithInvalidDefinitions,
-        secondaryTypeProperties
+        secondaryTypeProperties,
+        'attachments'
       );
   
       expect(result).toEqual([
@@ -777,7 +938,8 @@ describe("SDMAttachmentsService", () => {
         'attachment1',
         'file1.txt',
         { property1: 'value1' },
-        secondaryTypeProperties
+        secondaryTypeProperties,
+        'attachments'
       );
     });
   
@@ -790,7 +952,8 @@ describe("SDMAttachmentsService", () => {
         attachment,
         attachmentsEntity,
         secondaryPropertiesWithInvalidDefinitions,
-        secondaryTypeProperties
+        secondaryTypeProperties,
+        'attachments'
       );
   
       expect(result).toEqual([
@@ -805,7 +968,36 @@ describe("SDMAttachmentsService", () => {
         'attachment1',
         'file1.txt',
         { property1: 'value1' },
-        secondaryTypeProperties
+        secondaryTypeProperties,
+        'attachments'
+      );
+    });
+
+    // Test with 'references' composition name
+    it('should work with references composition name', async () => {
+      req.data = {
+        references: [{ ID: 'attachment1', filename: 'file1.txt' }]
+      };
+      isRestrictedCharactersInName.mockReturnValue(true);
+
+      const result = await service.updateNonDraftAttachments(
+        req,
+        token,
+        attachment,
+        attachmentsEntity,
+        secondaryPropertiesWithInvalidDefinitions,
+        secondaryTypeProperties,
+        'references'
+      );
+
+      expect(result).toEqual([{ typeOfError: 'restricted characters', name: 'file1.txt' }]);
+      expect(service.replacePropertiesInAttachment).toHaveBeenCalledWith(
+        req,
+        'attachment1',
+        'file1.txt',
+        { property1: 'value1' },
+        secondaryTypeProperties,
+        'references'
       );
     });
   });
@@ -826,7 +1018,7 @@ describe("SDMAttachmentsService", () => {
       req = {
         reject: jest.fn(),
         data: {
-          attachments: [{ ID: 'attachment1', filename: 'file1.txt' }]
+          references: [{ ID: 'attachment1', filename: 'file1.txt' }]
         }
       };
       token = 'mockToken';
@@ -856,7 +1048,8 @@ describe("SDMAttachmentsService", () => {
         attachment,
         attachmentsEntity,
         secondaryPropertiesWithInvalidDefinitions,
-        secondaryTypeProperties
+        secondaryTypeProperties,
+        'attachments'
       );
   
       expect(result).toEqual([{ typeOfError: 'restricted characters', name: 'file1.txt' }]);
@@ -865,7 +1058,8 @@ describe("SDMAttachmentsService", () => {
         'attachment1',
         'file1.txt',
         { property1: 'value1' },
-        secondaryTypeProperties
+        secondaryTypeProperties,
+        'attachments'
       );
     });
   
@@ -878,7 +1072,8 @@ describe("SDMAttachmentsService", () => {
         attachment,
         attachmentsEntity,
         secondaryPropertiesWithInvalidDefinitions,
-        secondaryTypeProperties
+        secondaryTypeProperties,
+        'attachments'
       );
   
       expect(response).toEqual(
@@ -895,7 +1090,8 @@ describe("SDMAttachmentsService", () => {
         attachment,
         attachmentsEntity,
         secondaryPropertiesWithInvalidDefinitions,
-        secondaryTypeProperties
+        secondaryTypeProperties,
+        'attachments'
       );
   
       expect(getUpdatedSecondaryProperties).toHaveBeenCalledWith(
@@ -923,7 +1119,8 @@ describe("SDMAttachmentsService", () => {
         attachment,
         attachmentsEntity,
         secondaryPropertiesWithInvalidDefinitions,
-        secondaryTypeProperties
+        secondaryTypeProperties,
+        'attachments'
       );
   
       expect(result).toEqual([{ typeOfError: 'no sdm roles', name: 'file1.txt' }]);
@@ -932,7 +1129,8 @@ describe("SDMAttachmentsService", () => {
         'attachment1',
         'file1.txt',
         { property1: 'value1' },
-        secondaryTypeProperties
+        secondaryTypeProperties,
+        'attachments'
       );
     });
   
@@ -945,7 +1143,8 @@ describe("SDMAttachmentsService", () => {
         attachment,
         attachmentsEntity,
         secondaryPropertiesWithInvalidDefinitions,
-        secondaryTypeProperties
+        secondaryTypeProperties,
+        'attachments'
       );
   
       expect(result).toEqual([{ typeOfError: 'duplicate', name: 'file1.txt' }]);
@@ -954,7 +1153,8 @@ describe("SDMAttachmentsService", () => {
         'attachment1',
         'file1.txt',
         { property1: 'value1' },
-        secondaryTypeProperties
+        secondaryTypeProperties,
+        'attachments'
       );
     });
   
@@ -967,7 +1167,8 @@ describe("SDMAttachmentsService", () => {
         attachment,
         attachmentsEntity,
         secondaryPropertiesWithInvalidDefinitions,
-        secondaryTypeProperties
+        secondaryTypeProperties,
+        'attachments'
       );
   
       expect(result).toEqual([{ typeOfError: 'not found', name: 'file1.txt' }]);
@@ -976,7 +1177,8 @@ describe("SDMAttachmentsService", () => {
         'attachment1',
         'file1.txt',
         { property1: 'value1' },
-        secondaryTypeProperties
+        secondaryTypeProperties,
+        'attachments'
       );
     });
 
@@ -985,7 +1187,7 @@ describe("SDMAttachmentsService", () => {
       service.getAttachementDataInSDM.mockResolvedValue({ filename: 'file1.txt', folderId: 'mockFolderId' });
       getPropertiesForID.mockResolvedValue({ property1: 'value1' });
       getUpdatedSecondaryProperties.mockReturnValue({ property1: 'updatedValue1' });
-      updateAttachment.mockResolvedValue(500); // Simulate an unexpected response code
+      updateAttachment.mockRejectedValue(new Error(sdmRolesErrorMessage)); // Simulate an unexpected response code
     
       // Call the method
       const result = await service.updateDraftAttachments(
@@ -994,7 +1196,8 @@ describe("SDMAttachmentsService", () => {
         attachment,
         attachmentsEntity,
         secondaryPropertiesWithInvalidDefinitions,
-        secondaryTypeProperties
+        secondaryTypeProperties,
+        'attachments'
       );
     
       expect(result).toEqual([
@@ -1011,7 +1214,8 @@ describe("SDMAttachmentsService", () => {
         'attachment1',
         'file1.txt',
         { property1: 'value1' },
-        secondaryTypeProperties
+        secondaryTypeProperties,
+        'attachments'
       );
     
       // Ensure updateAttachment was called with the correct arguments
@@ -1034,7 +1238,8 @@ describe("SDMAttachmentsService", () => {
         attachment,
         attachmentsEntity,
         secondaryPropertiesWithInvalidDefinitions,
-        secondaryTypeProperties
+        secondaryTypeProperties,
+        'attachments'
       );
   
       expect(result).toEqual([
@@ -1048,7 +1253,8 @@ describe("SDMAttachmentsService", () => {
         'attachment1',
         'file1.txt',
         { property1: 'value1' },
-        secondaryTypeProperties
+        secondaryTypeProperties,
+        'attachments'
       );
     });
   
@@ -1061,7 +1267,8 @@ describe("SDMAttachmentsService", () => {
         attachment,
         attachmentsEntity,
         secondaryPropertiesWithInvalidDefinitions,
-        secondaryTypeProperties
+        secondaryTypeProperties,
+        'attachments'
       );
   
       expect(result).toEqual([
@@ -1076,7 +1283,8 @@ describe("SDMAttachmentsService", () => {
         'attachment1',
         'file1.txt',
         { property1: 'value1' },
-        secondaryTypeProperties
+        secondaryTypeProperties,
+        'attachments'
       );
     });
   });
@@ -1091,7 +1299,7 @@ describe("SDMAttachmentsService", () => {
       service = new SDMAttachmentsService();
       req = {
         data: {
-          attachments: [
+          references: [
             { ID: 'attachment1', filename: 'oldFileName', property1: 'oldValue1', property2: 'oldValue2' },
             { ID: 'attachment2', filename: 'anotherOldFileName', property3: 'oldValue3' }
           ]
@@ -1107,9 +1315,9 @@ describe("SDMAttachmentsService", () => {
       const propertiesInDB = { property1: 'newValue1', property2: 'newValue2' };
       const fileName = 'newFileName';
   
-      service.replacePropertiesInAttachment(req, 'attachment1', fileName, propertiesInDB, secondaryTypeProperties);
+      service.replacePropertiesInAttachment(req, 'attachment1', fileName, propertiesInDB, secondaryTypeProperties, 'references');
   
-      const updatedAttachment = req.data.attachments.find(att => att.ID === 'attachment1');
+      const updatedAttachment = req.data.references.find(att => att.ID === 'attachment1');
       expect(updatedAttachment.filename).toBe('newFileName');
       expect(updatedAttachment.secondaryKey1).toBe('newValue1');
       expect(updatedAttachment.secondaryKey2).toBe('newValue2');
@@ -1118,9 +1326,9 @@ describe("SDMAttachmentsService", () => {
     it('should not modify properties if propertiesInDB is null', () => {
       const fileName = 'newFileName';
   
-      service.replacePropertiesInAttachment(req, 'attachment1', fileName, null, secondaryTypeProperties);
+      service.replacePropertiesInAttachment(req, 'attachment1', fileName, null, secondaryTypeProperties, 'references');
   
-      const updatedAttachment = req.data.attachments.find(att => att.ID === 'attachment1');
+      const updatedAttachment = req.data.references.find(att => att.ID === 'attachment1');
       expect(updatedAttachment.filename).toBe('newFileName');
       expect(updatedAttachment.property1).toBe('oldValue1'); // Ensure properties are not modified
       expect(updatedAttachment.property2).toBe('oldValue2');
@@ -1130,9 +1338,9 @@ describe("SDMAttachmentsService", () => {
       const propertiesInDB = { property1: 'newValue1', property2: 'newValue2' };
       const fileName = 'newFileName';
   
-      service.replacePropertiesInAttachment(req, 'nonExistentID', fileName, propertiesInDB, secondaryTypeProperties);
+      service.replacePropertiesInAttachment(req, 'nonExistentID', fileName, propertiesInDB, secondaryTypeProperties, 'references');
   
-      const updatedAttachment = req.data.attachments.find(att => att.ID === 'attachment1');
+      const updatedAttachment = req.data.references.find(att => att.ID === 'attachment1');
       expect(updatedAttachment.filename).toBe('oldFileName'); // Ensure filename is not modified
       expect(updatedAttachment.property1).toBe('oldValue1'); // Ensure properties are not modified
       expect(updatedAttachment.property2).toBe('oldValue2');
@@ -1142,9 +1350,9 @@ describe("SDMAttachmentsService", () => {
       const propertiesInDB = { property3: 'newValue3' }; // No matching keys in secondaryTypeProperties
       const fileName = 'newFileName';
   
-      service.replacePropertiesInAttachment(req, 'attachment1', fileName, propertiesInDB, secondaryTypeProperties);
+      service.replacePropertiesInAttachment(req, 'attachment1', fileName, propertiesInDB, secondaryTypeProperties, 'references');
   
-      const updatedAttachment = req.data.attachments.find(att => att.ID === 'attachment1');
+      const updatedAttachment = req.data.references.find(att => att.ID === 'attachment1');
       expect(updatedAttachment.filename).toBe('newFileName');
       expect(updatedAttachment.property1).toBe('oldValue1'); // Ensure properties are not modified
       expect(updatedAttachment.property2).toBe('oldValue2');
@@ -1154,9 +1362,9 @@ describe("SDMAttachmentsService", () => {
       const propertiesInDB = { property1: 'newValue1' }; // Only one matching property
       const fileName = 'newFileName';
   
-      service.replacePropertiesInAttachment(req, 'attachment1', fileName, propertiesInDB, secondaryTypeProperties);
+      service.replacePropertiesInAttachment(req, 'attachment1', fileName, propertiesInDB, secondaryTypeProperties, 'references');
   
-      const updatedAttachment = req.data.attachments.find(att => att.ID === 'attachment1');
+      const updatedAttachment = req.data.references.find(att => att.ID === 'attachment1');
       expect(updatedAttachment.filename).toBe('newFileName');
       expect(updatedAttachment.secondaryKey1).toBe('newValue1'); // Ensure matching property is updated
       expect(updatedAttachment.secondaryKey2).toBeUndefined(); // Ensure non-matching property is not updated
@@ -1349,7 +1557,7 @@ describe("SDMAttachmentsService", () => {
     });
 
     it('should handle _updateAttachments when Object.keys length is 0', async () => {
-      const req = { data: { attachments: [{ ID: '123', filename: 'test.txt' }] } };
+      const req = { data: { references: [{ ID: '123', filename: 'test.txt' }] } };
       const token = 'test-token';
       const attachment = { ID: '123', filename: 'test.txt' };
       const attachmentsEntity = {};
@@ -1467,7 +1675,7 @@ describe("SDMAttachmentsService", () => {
     it('should handle _updateAttachments when updatedSecondaryProperties is empty', async () => {
       const req = {
         data: {
-          attachments: [{
+          references: [{
             ID: 'attachment-123',
             filename: 'test.txt'
           }]
@@ -1999,9 +2207,20 @@ describe("SDMAttachmentsService", () => {
       getRepositoryInfo.mockResolvedValueOnce(repoInfo);
       isRepositoryVersioned.mockResolvedValueOnce(false);
       
-      cds.model.definitions["myName.attachments"] = {};
-      cds.model.definitions["Attachments.attachments"] = {};
-      cds.model.definitions["testName.attachments"] = {};
+      // Setup entity with composition
+      cds.model.definitions["myName"] = {
+        elements: {
+          references: {
+            type: 'cds.Composition',
+            target: 'myName.references'
+          }
+        }
+      };
+      cds.model.definitions["myName.references"] = {
+        includes: ['sap.attachments.Attachments']
+      };
+      cds.model.definitions["Attachments.references"] = {};
+      cds.model.definitions["testName.references"] = {};
     });
     it("should add attachments to delete in req when deletions are present", async () => {
       const mockedReq = {
@@ -2014,7 +2233,7 @@ describe("SDMAttachmentsService", () => {
           },
         },
         diff: jest.fn().mockResolvedValueOnce({
-          attachments: [
+          references: [
             { _op: "delete", ID: "1" },
             { _op: "delete", ID: "2" },
             { _op: "insert", ID: "3" },
@@ -2022,7 +2241,7 @@ describe("SDMAttachmentsService", () => {
         }),
         attachmentsToDelete: undefined,
       };
-      const mockedAttachments = cds.model.definitions["myName.attachments"];
+      const mockedAttachments = cds.model.definitions["myName.references"];
 
       getURLsToDeleteFromAttachments.mockResolvedValueOnce([
         "attachment3",
@@ -2051,7 +2270,7 @@ describe("SDMAttachmentsService", () => {
           },
         },
         diff: jest.fn().mockResolvedValueOnce({
-          attachments: [],
+          references: [],
         }),
         attachmentsToDelete: undefined,
       };
@@ -2073,11 +2292,11 @@ describe("SDMAttachmentsService", () => {
           },
         },
         diff: jest.fn().mockResolvedValueOnce({
-          attachments: [],
+          references: [],
         }),
         attachmentsToDelete: undefined,
       };
-      delete cds.model.definitions["myOtherName.attachments"];
+      delete cds.model.definitions["myOtherName.references"];
       await service.attachDeletionData(mockedReq);
       expect(mockedReq.diff).not.toHaveBeenCalled(); // Diff is not called if attachments entity is undefined
       expect(getURLsToDeleteFromAttachments).not.toHaveBeenCalled();
@@ -2085,6 +2304,18 @@ describe("SDMAttachmentsService", () => {
     });
 
     it("attachDeletionData() should set req.parentId if event is DELETE and getFolderIdForEntity() returns non-empty array", async () => {
+      cds.model.definitions["Attachments"] = {
+        elements: {
+          references: {
+            type: 'cds.Composition',
+            target: 'Attachments.references'
+          }
+        }
+      };
+      cds.model.definitions["Attachments.references"] = {
+        includes: ['sap.attachments.Attachments']
+      };
+      
       const mockedReq = {
         target: {
           name: 'Attachments',
@@ -2095,7 +2326,7 @@ describe("SDMAttachmentsService", () => {
           },
         },
         diff: () =>
-          Promise.resolve({ attachments: [{ _op: "delete", ID: "1" }] }),
+          Promise.resolve({ references: [{ _op: "delete", ID: "1" }] }),
         event: "DELETE",
       };
 
@@ -2103,11 +2334,23 @@ describe("SDMAttachmentsService", () => {
       getURLsToDeleteFromAttachments.mockResolvedValueOnce(["url"]);
       getFolderIdByIDAsPath.mockResolvedValueOnce("folder");
       await service.attachDeletionData(mockedReq);
-      expect(mockedReq.parentId).toEqual("folder");
+      expect(mockedReq.parentId).toEqual(["folder"]);
       expect(getFolderIdByIDAsPath).toHaveBeenCalledTimes(1);
     });
 
     it("attachDeletionData() should not set req.parentId if event is DELETE and getFolderIdForEntity() returns empty array", async () => {
+      cds.model.definitions["Attachments"] = {
+        elements: {
+          references: {
+            type: 'cds.Composition',
+            target: 'Attachments.references'
+          }
+        }
+      };
+      cds.model.definitions["Attachments.references"] = {
+        includes: ['sap.attachments.Attachments']
+      };
+      
       const mockedReq = {
         target: {
           name: 'Attachments',
@@ -2118,18 +2361,16 @@ describe("SDMAttachmentsService", () => {
           },
         },
         diff: () =>
-          Promise.resolve({ attachments: [{ _op: "delete", ID: "1" }] }),
+          Promise.resolve({ references: [{ _op: "delete", ID: "1" }] }),
         event: "DELETE",
       };
-      
+
       getURLsToDeleteFromAttachments.mockResolvedValueOnce(["url"]);
       getFolderIdByIDAsPath.mockResolvedValueOnce(null);
       await service.attachDeletionData(mockedReq);
       expect(mockedReq.parentId).toBeUndefined();
       expect(getFolderIdByIDAsPath).toHaveBeenCalledTimes(1);
-    });
-
-    it("attachDeletionData() should not call getFolderIdForEntity() if event is not DELETE", async () => {
+    });    it("attachDeletionData() should not call getFolderIdForEntity() if event is not DELETE", async () => {
       const mockReq = {
         target: { name: "testName" },
         user: {
@@ -2138,7 +2379,7 @@ describe("SDMAttachmentsService", () => {
           },
         },
         diff: () =>
-          Promise.resolve({ attachments: [{ _op: "delete", ID: "1" }] }),
+          Promise.resolve({ references: [{ _op: "delete", ID: "1" }] }),
         event: "CREATE",
       };
 
@@ -2156,7 +2397,7 @@ describe("SDMAttachmentsService", () => {
           },
         },
         diff: () =>
-          Promise.resolve({ attachments: [{ _op: "delete", ID: "1" }] }),
+          Promise.resolve({ references: [{ _op: "delete", ID: "1" }] }),
       };
       getURLsToDeleteFromAttachments.mockResolvedValueOnce([]); // returning empty array
       await service.attachDeletionData(mockReq);
@@ -2255,7 +2496,7 @@ describe("SDMAttachmentsService", () => {
 
       const expectedErrorResponse = "test_error_response";
 
-      cds.model.definitions["testTarget.attachments"] = {};
+      cds.model.definitions["testTarget.references"] = {};
       fetchAccessToken.mockResolvedValueOnce("test_token");
       deleteAttachmentsOfFolder.mockResolvedValue({});
       service.handleRequest = jest
@@ -2368,7 +2609,7 @@ describe("SDMAttachmentsService", () => {
         warn: jest.fn()
       };
 
-      cds.model.definitions[mockReq.target.name + ".attachments"] = {
+      cds.model.definitions[mockReq.target.name + ".references"] = {
         keys: {
           up_: {
             keys: [{ ref: ["attachment"] }],
@@ -2958,20 +3199,40 @@ describe("SDMAttachmentsService", () => {
     it('should handle entity patterns when no target name', async () => {
       req.target = {}; // Simulate no target name
       
+      // Mock the parent entity with references composition
+      cds.model.definitions['ProcessorService.Incidents'] = {
+        elements: {
+          references: {
+            type: 'cds.Composition',
+            target: 'ProcessorService.Incidents.references'
+          }
+        }
+      };
+      
       // Mock the entity definitions that the method looks for
-      cds.model.definitions['ProcessorService.Incidents.attachments'] = { entity: 'TestAttachments' };
-      cds.model.definitions['ProcessorService.Incidents.attachments.drafts'] = { entity: 'TestAttachmentsDrafts' };
+      cds.model.definitions['ProcessorService.Incidents.references'] = { 
+        entity: 'TestAttachments',
+        includes: ['sap.attachments.Attachments']
+      };
+      cds.model.definitions['ProcessorService.Incidents.references.drafts'] = { 
+        entity: 'TestAttachmentsDrafts'
+      };
       
       await service.handleDraftSaveForLinks(req);
       
       // FIX: Assert calls to the spied function
-      expect(service.updateBaselinesForEntity).toHaveBeenCalledWith('ProcessorService.Incidents.attachments');
-      expect(service.updateBaselinesForEntity).toHaveBeenCalledWith('ProcessorService.Incidents.attachments.drafts');
+      expect(service.updateBaselinesForEntity).toHaveBeenCalledWith('ProcessorService.Incidents.references');
+      expect(service.updateBaselinesForEntity).toHaveBeenCalledWith('ProcessorService.Incidents.references.drafts');
       expect(service.updateBaselinesForEntity).toHaveBeenCalledTimes(2);
     });
     
     it('should not call updateBaselinesForEntity when target name is available', async () => {
       // Target name is available: 'Test.Entity.drafts'
+      
+      // Clean up entity definitions from previous test
+      delete cds.model.definitions['ProcessorService.Incidents'];
+      delete cds.model.definitions['ProcessorService.Incidents.references'];
+      delete cds.model.definitions['ProcessorService.Incidents.references.drafts'];
       
       await service.handleDraftSaveForLinks(req);
       
@@ -3074,7 +3335,18 @@ describe("SDMAttachmentsService", () => {
       global.SELECT.where.mockClear();
       
       // FIX: Add mock key structure for the target entity's attachments draft
-      cds.model.definitions['Parent.attachments.drafts'] = mockUpKeyStructure;
+      cds.model.definitions['Parent'] = {
+        elements: {
+          references: {
+            type: 'cds.Composition',
+            target: 'Parent.references'
+          }
+        }
+      };
+      cds.model.definitions['Parent.references'] = {
+        includes: ['sap.attachments.Attachments']
+      };
+      cds.model.definitions['Parent.references.drafts'] = mockUpKeyStructure;
       
       fetchAccessToken.mockResolvedValue('access-token');
     });
@@ -3140,7 +3412,7 @@ describe("SDMAttachmentsService", () => {
       req.target.name = 'NonExistent.drafts';
       
       // Provide a minimal entity definition to prevent the crash
-      cds.model.definitions['NonExistent.attachments.drafts'] = {
+      cds.model.definitions['NonExistent.references.drafts'] = {
         keys: {
           up_: {
             keys: [{
@@ -3252,7 +3524,7 @@ describe("SDMAttachmentsService", () => {
         info: jest.fn(),
       };
 
-      cds.model.definitions[mockReq.target.name + ".attachments"] = {
+      cds.model.definitions[mockReq.target.name + ".references"] = {
         keys: {
           up_: {
             keys: [{ ref: ["attachment"] }],
@@ -3262,7 +3534,7 @@ describe("SDMAttachmentsService", () => {
     });
 
     it("getParentId should call getFolderIdByPath if getFolderIdForEntity returns empty array", async () => {
-      const attachments = cds.model.definitions[mockReq.target.name + ".attachments"]
+      const attachments = cds.model.definitions[mockReq.target.name + ".references"]
       const token = "mocked_token"
       getFolderIdForEntity.mockResolvedValueOnce([]);
       getFolderIdByPath.mockResolvedValueOnce("mocked_folder_id");
@@ -3274,13 +3546,13 @@ describe("SDMAttachmentsService", () => {
         mockReq,
         service.creds,
         "mocked_token",
-        cds.model.definitions[mockReq.target.name + ".attachments"],
+        cds.model.definitions[mockReq.target.name + ".references"],
         upId
       );
     });
   
     it("getParentId should call createFolder if getFolderIdForEntity and getFolderIdByPath return empty", async () => {
-      let attachments = cds.model.definitions[mockReq.target.name + ".attachments"]
+      let attachments = cds.model.definitions[mockReq.target.name + ".references"]
       let token = "mocked_token"
       getFolderIdForEntity.mockResolvedValueOnce([]);
       getFolderIdByPath.mockResolvedValueOnce(null);
@@ -3301,13 +3573,13 @@ describe("SDMAttachmentsService", () => {
         mockReq,
         service.creds,
         "mocked_token",
-        cds.model.definitions[mockReq.target.name + ".attachments"],
+        cds.model.definitions[mockReq.target.name + ".references"],
         upId
       );
     });
   
     it("getParentId should reject with 403 if createFolder response status is 403 and message matches userDoesNotHaveRequiredScope", async () => {
-      let attachments = cds.model.definitions[mockReq.target.name + ".attachments"];
+      let attachments = cds.model.definitions[mockReq.target.name + ".references"];
       let token = "mocked_token";
       getFolderIdForEntity.mockResolvedValueOnce([]);
       getFolderIdByPath.mockResolvedValueOnce(null);
@@ -3329,7 +3601,7 @@ describe("SDMAttachmentsService", () => {
     });
 
     it("getParentId should return parentId if folderId is not null in folderIds", async () => {
-      let attachments = cds.model.definitions[mockReq.target.name + ".attachments"];
+      let attachments = cds.model.definitions[mockReq.target.name + ".references"];
       let token = "mocked_token";
 
       const folderIds = [
@@ -3533,17 +3805,30 @@ describe("SDMAttachmentsService", () => {
         diff: jest.fn(),
       };
   
-      cds.model.definitions["testName.attachments.drafts"] = {};
+      cds.model.definitions["testName"] = {
+        elements: {
+          references: {
+            type: 'cds.Composition',
+            target: 'testName.references'
+          }
+        }
+      };
+      cds.model.definitions["testName.references"] = {
+        includes: ['sap.attachments.Attachments']
+      };
+      cds.model.definitions["testName.references.drafts"] = {
+        includes: ['sap.attachments.Attachments']
+      };
     });
   
     it("should attach attachments to delete in req when they are present in drafts", async () => {
-      mockDraftAttachments = cds.model.definitions["testName.attachments.drafts"];
+      mockDraftAttachments = cds.model.definitions["testName.references.drafts"];
   
       const attachmentsToDelete = ["attachment1", "attachment2"];
       getURLsToDeleteFromDraftAttachments.mockResolvedValueOnce(attachmentsToDelete);
   
       mockReq.diff.mockResolvedValueOnce({
-        attachments: ["attachment1", "attachment2"],
+        references: ["attachment1", "attachment2"],
       });
   
       fetchAccessToken.mockResolvedValueOnce("mocked_token");
@@ -3553,7 +3838,7 @@ describe("SDMAttachmentsService", () => {
   
       expect(getURLsToDeleteFromDraftAttachments).toHaveBeenCalledWith("mocked_id", mockDraftAttachments);
       expect(mockReq.attachmentsToDelete).toEqual(attachmentsToDelete);
-      expect(mockReq.parentId).toEqual("mock_folder_id");
+      expect(mockReq.parentId).toEqual(["mock_folder_id"]);
     });
   
     it("should not set `parentId` if the number of attachments in diff is different from `attachmentsToDelete`", async () => {
@@ -3561,7 +3846,7 @@ describe("SDMAttachmentsService", () => {
       getURLsToDeleteFromDraftAttachments.mockResolvedValueOnce(attachmentsToDelete);
   
       mockReq.diff.mockResolvedValueOnce({
-        attachments: ["attachment1", "attachment2", "attachment3"],
+        references: ["attachment1", "attachment2", "attachment3"],
       });
   
       await service.attachDraftDeletionData(mockReq);
@@ -3570,7 +3855,7 @@ describe("SDMAttachmentsService", () => {
     });
   
     it("should not attach attachments to delete if no draft attachments are found", async () => {
-      delete cds.model.definitions["testName.attachments.drafts"];
+      delete cds.model.definitions["testName.references.drafts"];
       getURLsToDeleteFromDraftAttachments.mockResolvedValueOnce([]);
   
       await service.attachDraftDeletionData(mockReq);
@@ -3583,7 +3868,7 @@ describe("SDMAttachmentsService", () => {
       getURLsToDeleteFromDraftAttachments.mockResolvedValueOnce([]); // Empty array to simulate no deletions
   
       mockReq.diff.mockResolvedValueOnce({
-        attachments: ["attachment1", "attachment2"],
+        references: ["attachment1", "attachment2"],
       });
   
       await service.attachDraftDeletionData(mockReq);
@@ -3602,7 +3887,7 @@ describe("SDMAttachmentsService", () => {
       
       // Both arrays should be of the same length to trigger folderId fetch logic
       mockReq.diff.mockResolvedValueOnce({
-        attachments: ["attachment1", "attachment2"],
+        references: ["attachment1", "attachment2"],
       });
   
       // Simulate fetching a token, but folder ID fetch returns falsy

--- a/test/lib/sdm.test.js
+++ b/test/lib/sdm.test.js
@@ -52,6 +52,7 @@ let {
   duplicateFileErr,
   otherFileErr,
   userNotAuthorisedError,
+  userNotAuthorisedReadError,
   userDoesNotHaveRequiredScope,
   versionedRepositoryErr,
   nameConstrainErr,
@@ -60,7 +61,9 @@ let {
   userNotAuthorisedOpenLink,
   editLinkNotFoundErr,
   linkNameConstraintMessage,
-  unsupportedProperties
+  unsupportedProperties,
+  attachmentNotFound,
+  errorMessage
 } = require("../../lib/util/messageConsts");
 
 jest.mock("@cap-js/attachments/lib/basic", () => class {});
@@ -133,6 +136,14 @@ jest.mock("@sap/cds/lib", () => {
   return mockCds;
 });
 jest.mock("node-cache");
+
+// Mock the cache instance used in sdm.js
+const mockCacheInstance = {
+  get: jest.fn(),
+  set: jest.fn(),
+  del: jest.fn()
+};
+NodeCache.mockImplementation(() => mockCacheInstance);
 
 // Global Mocks for CAP Query Functions (Used in Link Persistence Logic)
 global.SELECT = {
@@ -1286,6 +1297,37 @@ describe("SDMAttachmentsService", () => {
         secondaryTypeProperties,
         'attachments'
       );
+    });
+
+    it('should handle unexpected status code (default case) by throwing error', async () => {
+      // Mock dependencies
+      getFileNameForAttachmentID.mockResolvedValue('file1.txt');
+      getPropertiesForID.mockResolvedValue({ property1: 'value1' });
+      getUpdatedSecondaryProperties.mockReturnValue({ property1: 'updatedValue1' });
+      // Return an unexpected status code (e.g., 500) that triggers default case
+      updateAttachment.mockResolvedValue(500);
+    
+      // Call the method
+      const result = await service.updateNonDraftAttachments(
+        req,
+        token,
+        attachment,
+        attachmentsEntity,
+        secondaryPropertiesWithInvalidDefinitions,
+        secondaryTypeProperties,
+        'attachments'
+      );
+    
+      // The default case throws an error which is caught and added to failedReq
+      expect(result).toEqual([
+        {
+          typeOfError: 'bad request',
+          name: 'file1.txt',
+          message: sdmRolesErrorMessage
+        }
+      ]);
+      
+      expect(service.replacePropertiesInAttachment).toHaveBeenCalled();
     });
   });
 
@@ -4041,6 +4083,594 @@ describe("SDMAttachmentsService", () => {
       expect(service.handleEditLinkAction).toHaveBeenCalledWith(req);
       expect(result).toBe("editLinkResult");
       expect(req.error).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('checkRepositoryType', () => {
+    let service;
+
+    beforeEach(() => {
+      jest.clearAllMocks();
+      service = new SDMAttachmentsService();
+      service.creds = { key: 'test-creds' };
+    });
+
+    it('should reject with error when repository is versioned', async () => {
+      const req = { reject: jest.fn() };
+      
+      // Mock getConfigurations to return a repositoryId
+      getConfigurations.mockReturnValue({ repositoryId: 'test-repo' });
+      
+      // Mock user token info
+      cds.context = {
+        user: {
+          tokenInfo: {
+            getPayload: () => ({ ext_attr: { zdn: 'test-subdomain' } })
+          }
+        }
+      };
+      
+      // Mock cache to return undefined (not cached)
+      mockCacheInstance.get.mockReturnValue(undefined);
+      
+      // Mock repository info calls
+      getClientCredentialsToken.mockResolvedValue('test-token');
+      getRepositoryInfo.mockResolvedValue({ capabilities: {} });
+      isRepositoryVersioned.mockReturnValue(true);
+      
+      await service.checkRepositoryType(req);
+      
+      expect(req.reject).toHaveBeenCalledWith(400, versionedRepositoryErr);
+    });
+
+    it('should reject with error when cached repository type is versioned', async () => {
+      const req = { reject: jest.fn() };
+      
+      getConfigurations.mockReturnValue({ repositoryId: 'test-repo' });
+      
+      cds.context = {
+        user: {
+          tokenInfo: {
+            getPayload: () => ({ ext_attr: { zdn: 'test-subdomain' } })
+          }
+        }
+      };
+      
+      // Mock cache to return "versioned"
+      mockCacheInstance.get.mockReturnValue('versioned');
+      
+      // Create service AFTER setting up mocks
+      const cachedService = new SDMAttachmentsService();
+      cachedService.creds = { key: 'test-creds' };
+      
+      await cachedService.checkRepositoryType(req);
+      
+      expect(req.reject).toHaveBeenCalledWith(400, versionedRepositoryErr);
+    });
+  });
+
+  describe('get method error paths', () => {
+    let service;
+
+    beforeEach(() => {
+      jest.clearAllMocks();
+      service = new SDMAttachmentsService();
+      service.creds = { key: 'test-creds' };
+    });
+
+    it('should reject with 403 when content is "Forbidden"', async () => {
+      const req = {
+        reject: jest.fn(),
+        user: { tokenInfo: { getTokenValue: () => 'test-token' } }
+      };
+      const keys = { ID: 'test-id' };
+      const attachments = {};
+
+      getURLFromAttachments.mockResolvedValue({ url: 'test-url' });
+      fetchAccessToken.mockResolvedValue('test-token');
+      readAttachment.mockResolvedValue('Forbidden');
+
+      await service.get(attachments, keys, req);
+
+      expect(req.reject).toHaveBeenCalledWith(403, userNotAuthorisedReadError);
+    });
+
+    it('should reject with 404 when content is "Not Found"', async () => {
+      const req = {
+        reject: jest.fn(),
+        user: { tokenInfo: { getTokenValue: () => 'test-token' } }
+      };
+      const keys = { ID: 'test-id' };
+      const attachments = {};
+
+      getURLFromAttachments.mockResolvedValue({ url: 'test-url' });
+      fetchAccessToken.mockResolvedValue('test-token');
+      readAttachment.mockResolvedValue('Not Found');
+
+      await service.get(attachments, keys, req);
+
+      expect(req.reject).toHaveBeenCalledWith(404, attachmentNotFound);
+    });
+
+    it('should reject with 500 for other error types', async () => {
+      const req = {
+        reject: jest.fn(),
+        user: { tokenInfo: { getTokenValue: () => 'test-token' } }
+      };
+      const keys = { ID: 'test-id' };
+      const attachments = {};
+
+      getURLFromAttachments.mockResolvedValue({ url: 'test-url' });
+      fetchAccessToken.mockResolvedValue('test-token');
+      readAttachment.mockResolvedValue('Some other error');
+
+      await service.get(attachments, keys, req);
+
+      expect(req.reject).toHaveBeenCalledWith(500, errorMessage);
+    });
+  });
+
+  describe('processCompositionRename', () => {
+    let service;
+
+    beforeEach(() => {
+      jest.clearAllMocks();
+      service = new SDMAttachmentsService();
+      service.creds = { key: 'test-creds' };
+    });
+
+    it('should return early when attachmentsEntity does not exist', async () => {
+      const req = {
+        target: { name: 'Test.Entity' },
+        data: {}
+      };
+      
+      // Mock entity definition to not exist
+      cds.model.definitions['Test.Entity.references'] = undefined;
+      
+      const result = await service.processCompositionRename(req, 'references', 'test-repo');
+      
+      expect(result).toBeUndefined();
+    });
+  });
+
+  describe('getAttachmentCompositions', () => {
+    let service;
+
+    beforeEach(() => {
+      jest.clearAllMocks();
+      service = new SDMAttachmentsService();
+    });
+
+    it('should return empty array when entity definition does not exist', () => {
+      const targetEntity = { name: 'NonExistent.Entity' };
+      
+      delete cds.model.definitions['NonExistent.Entity'];
+      
+      const result = service.getAttachmentCompositions(targetEntity);
+      
+      expect(result).toEqual([]);
+    });
+
+    it('should return empty array when entity has no elements', () => {
+      const targetEntity = { name: 'Test.EmptyEntity' };
+      
+      cds.model.definitions['Test.EmptyEntity'] = {};
+      
+      const result = service.getAttachmentCompositions(targetEntity);
+      
+      expect(result).toEqual([]);
+    });
+
+    it('should find composition named "references"', () => {
+      const targetEntity = { name: 'Test.EntityWithReferences' };
+      
+      cds.model.definitions['Test.EntityWithReferences'] = {
+        elements: {
+          references: {
+            type: 'cds.Composition',
+            target: 'Test.References'
+          }
+        }
+      };
+      
+      cds.model.definitions['Test.References'] = {
+        includes: ['sap.attachments.Attachments']
+      };
+      
+      const result = service.getAttachmentCompositions(targetEntity);
+      
+      expect(result).toEqual(['references']);
+    });
+
+    it('should find composition named "attachments"', () => {
+      const targetEntity = { name: 'Test.EntityWithAttachments' };
+      
+      cds.model.definitions['Test.EntityWithAttachments'] = {
+        elements: {
+          attachments: {
+            type: 'cds.Composition',
+            target: 'Test.Attachments'
+          }
+        }
+      };
+      
+      cds.model.definitions['Test.Attachments'] = {
+        includes: ['sap.attachments.Attachments']
+      };
+      
+      const result = service.getAttachmentCompositions(targetEntity);
+      
+      expect(result).toEqual(['attachments']);
+    });
+
+    it('should find composition with custom name "documents"', () => {
+      const targetEntity = { name: 'Test.EntityWithDocuments' };
+      
+      cds.model.definitions['Test.EntityWithDocuments'] = {
+        elements: {
+          documents: {
+            type: 'cds.Composition',
+            target: 'Test.Documents'
+          }
+        }
+      };
+      
+      cds.model.definitions['Test.Documents'] = {
+        includes: ['sap.attachments.Attachments']
+      };
+      
+      const result = service.getAttachmentCompositions(targetEntity);
+      
+      expect(result).toEqual(['documents']);
+    });
+
+    it('should find composition with custom name "files"', () => {
+      const targetEntity = { name: 'Test.EntityWithFiles' };
+      
+      cds.model.definitions['Test.EntityWithFiles'] = {
+        elements: {
+          files: {
+            type: 'cds.Composition',
+            target: 'Test.Files'
+          }
+        }
+      };
+      
+      cds.model.definitions['Test.Files'] = {
+        includes: ['sap.attachments.Attachments']
+      };
+      
+      const result = service.getAttachmentCompositions(targetEntity);
+      
+      expect(result).toEqual(['files']);
+    });
+
+    it('should find multiple attachment compositions with different names', () => {
+      const targetEntity = { name: 'Test.EntityWithMultipleCompositions' };
+      
+      cds.model.definitions['Test.EntityWithMultipleCompositions'] = {
+        elements: {
+          references: {
+            type: 'cds.Composition',
+            target: 'Test.References'
+          },
+          documents: {
+            type: 'cds.Composition',
+            target: 'Test.Documents'
+          },
+          files: {
+            type: 'cds.Composition',
+            target: 'Test.Files'
+          }
+        }
+      };
+      
+      cds.model.definitions['Test.References'] = {
+        includes: ['sap.attachments.Attachments']
+      };
+      cds.model.definitions['Test.Documents'] = {
+        includes: ['sap.attachments.Attachments']
+      };
+      cds.model.definitions['Test.Files'] = {
+        includes: ['sap.attachments.Attachments']
+      };
+      
+      const result = service.getAttachmentCompositions(targetEntity);
+      
+      expect(result).toContain('references');
+      expect(result).toContain('documents');
+      expect(result).toContain('files');
+      expect(result.length).toBe(3);
+    });
+
+    it('should ignore compositions that do not have sap.attachments.Attachments includes', () => {
+      const targetEntity = { name: 'Test.EntityWithMixedCompositions' };
+      
+      cds.model.definitions['Test.EntityWithMixedCompositions'] = {
+        elements: {
+          references: {
+            type: 'cds.Composition',
+            target: 'Test.References'
+          },
+          otherComposition: {
+            type: 'cds.Composition',
+            target: 'Test.OtherEntity'
+          }
+        }
+      };
+      
+      cds.model.definitions['Test.References'] = {
+        includes: ['sap.attachments.Attachments']
+      };
+      cds.model.definitions['Test.OtherEntity'] = {
+        includes: ['SomeOtherAspect']
+      };
+      
+      const result = service.getAttachmentCompositions(targetEntity);
+      
+      expect(result).toEqual(['references']);
+    });
+
+    it('should ignore non-composition elements', () => {
+      const targetEntity = { name: 'Test.EntityWithMixedElements' };
+      
+      cds.model.definitions['Test.EntityWithMixedElements'] = {
+        elements: {
+          references: {
+            type: 'cds.Composition',
+            target: 'Test.References'
+          },
+          title: {
+            type: 'cds.String'
+          },
+          status: {
+            type: 'cds.Integer'
+          }
+        }
+      };
+      
+      cds.model.definitions['Test.References'] = {
+        includes: ['sap.attachments.Attachments']
+      };
+      
+      const result = service.getAttachmentCompositions(targetEntity);
+      
+      expect(result).toEqual(['references']);
+    });
+
+    it('should handle composition without target definition', () => {
+      const targetEntity = { name: 'Test.EntityWithBrokenComposition' };
+      
+      cds.model.definitions['Test.EntityWithBrokenComposition'] = {
+        elements: {
+          references: {
+            type: 'cds.Composition',
+            target: 'Test.NonExistentTarget'
+          }
+        }
+      };
+      
+      // Target definition doesn't exist
+      delete cds.model.definitions['Test.NonExistentTarget'];
+      
+      const result = service.getAttachmentCompositions(targetEntity);
+      
+      expect(result).toEqual([]);
+    });
+
+    it('should handle composition target without includes property', () => {
+      const targetEntity = { name: 'Test.EntityWithIncompleteTarget' };
+      
+      cds.model.definitions['Test.EntityWithIncompleteTarget'] = {
+        elements: {
+          references: {
+            type: 'cds.Composition',
+            target: 'Test.IncompleteTarget'
+          }
+        }
+      };
+      
+      cds.model.definitions['Test.IncompleteTarget'] = {
+        // No includes property
+      };
+      
+      const result = service.getAttachmentCompositions(targetEntity);
+      
+      expect(result).toEqual([]);
+    });
+
+    it('should work with any composition name following naming convention', () => {
+      const testCases = [
+        'attachments',
+        'references',
+        'documents',
+        'files',
+        'media',
+        'uploads',
+        'resources',
+        'assets',
+        'binaries'
+      ];
+
+      testCases.forEach(compositionName => {
+        const targetEntity = { name: `Test.EntityWith${compositionName}` };
+        
+        cds.model.definitions[`Test.EntityWith${compositionName}`] = {
+          elements: {
+            [compositionName]: {
+              type: 'cds.Composition',
+              target: `Test.${compositionName}`
+            }
+          }
+        };
+        
+        cds.model.definitions[`Test.${compositionName}`] = {
+          includes: ['sap.attachments.Attachments']
+        };
+        
+        const result = service.getAttachmentCompositions(targetEntity);
+        
+        expect(result).toEqual([compositionName]);
+      });
+    });
+  });
+
+  describe('replacePropertiesInAttachment', () => {
+    let service;
+
+    beforeEach(() => {
+      jest.clearAllMocks();
+      service = new SDMAttachmentsService();
+    });
+
+    it('should return early when req.data does not have compositionName', () => {
+      const req = { data: {} };
+      const id = 'test-id';
+      const fileName = 'test.pdf';
+      const propertiesInDB = {};
+      const secondaryTypeProperties = new Map();
+      const compositionName = 'references';
+      
+      service.replacePropertiesInAttachment(req, id, fileName, propertiesInDB, secondaryTypeProperties, compositionName);
+      
+      // Should return early without error
+      expect(req.data[compositionName]).toBeUndefined();
+    });
+
+    it('should return early when attachment with ID is not found', () => {
+      const req = { 
+        data: { 
+          references: [
+            { ID: 'other-id', filename: 'other.pdf' }
+          ] 
+        } 
+      };
+      const id = 'test-id';
+      const fileName = 'test.pdf';
+      const propertiesInDB = {};
+      const secondaryTypeProperties = new Map();
+      const compositionName = 'references';
+      
+      service.replacePropertiesInAttachment(req, id, fileName, propertiesInDB, secondaryTypeProperties, compositionName);
+      
+      // Attachment filename should not be changed
+      expect(req.data.references[0].filename).toBe('other.pdf');
+    });
+  });
+
+  describe('attachDraftDeletionData - edge cases', () => {
+    let service;
+
+    beforeEach(() => {
+      jest.clearAllMocks();
+      service = new SDMAttachmentsService();
+      service.creds = { key: 'test-creds' };
+    });
+
+    it('should handle when draftAttachments entity does not exist', async () => {
+      const req = {
+        target: { name: 'Test.Entity.drafts' },
+        data: { ID: 'test-id' },
+        diff: jest.fn().mockResolvedValue({ references: [] }),
+        event: 'DELETE',
+        user: {
+          tokenInfo: { getTokenValue: () => 'test-token' }
+        }
+      };
+
+      cds.model.definitions['Test.Entity'] = {
+        elements: {
+          references: {
+            type: 'cds.Composition',
+            target: 'Test.Entity.references'
+          }
+        }
+      };
+      
+      cds.model.definitions['Test.Entity.references'] = {
+        includes: ['sap.attachments.Attachments']
+      };
+      
+      // Draft entity doesn't exist
+      delete cds.model.definitions['Test.Entity.references.drafts'];
+      
+      await service.attachDraftDeletionData(req);
+      
+      // Should not throw and should not set attachmentsToDelete
+      expect(req.attachmentsToDelete).toBeUndefined();
+    });
+  });
+
+  describe('handleDraftDiscardForLinks - edge cases', () => {
+    let service;
+
+    beforeEach(() => {
+      jest.clearAllMocks();
+      service = new SDMAttachmentsService();
+      service.originalUrlMap = new Map();
+      service.creds = { key: 'test-creds' };
+    });
+
+    it('should continue when attachmentsEntity does not exist', async () => {
+      const req = {
+        target: { name: 'Test.Entity.drafts' },
+        data: { ID: 'test-id' },
+        user: {
+          tokenInfo: { getTokenValue: () => 'test-token' }
+        }
+      };
+
+      cds.model.definitions['Test.Entity'] = {
+        elements: {
+          references: {
+            type: 'cds.Composition',
+            target: 'Test.Entity.references'
+          }
+        }
+      };
+      
+      cds.model.definitions['Test.Entity.references'] = {
+        includes: ['sap.attachments.Attachments']
+      };
+      
+      // Draft entity doesn't exist
+      delete cds.model.definitions['Test.Entity.references.drafts'];
+      
+      fetchAccessToken.mockResolvedValue('test-token');
+      
+      await service.handleDraftDiscardForLinks(req);
+      
+      // Should not throw
+      expect(fetchAccessToken).toHaveBeenCalled();
+    });
+  });
+
+  describe('handleDraftDiscardForLinks - missing entity', () => {
+    let service;
+
+    beforeEach(() => {
+      jest.clearAllMocks();
+      service = new SDMAttachmentsService();
+      service.originalUrlMap = new Map();
+    });
+
+    it('should handle missing entity definition gracefully', async () => {
+      const req = {
+        target: { name: 'NonExistent.Entity.drafts' },
+        data: { ID: 'test-id' },
+        user: {
+          tokenInfo: { getTokenValue: () => 'test-token' }
+        }
+      };
+
+      // Ensure entity doesn't exist
+      delete cds.model.definitions['NonExistent.Entity'];
+      
+      await service.handleDraftDiscardForLinks(req);
+      
+      // Should not throw and should not call any SDM operations
+      expect(fetchAccessToken).not.toHaveBeenCalled();
     });
   });
 


### PR DESCRIPTION
SDM cap-js plugin will not work if Composition of many Attachments has the name other than "attachments"

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist before requesting a review

- [x] I have tested the functionality on my cloud environment.
- [ ] I have  provided sufficient automated/ unit tests for the code.
- [ ] I have increased or maintained the test coverage.
- [ ] I have ran integration tests on my cloud environment.
- [ ] I have validated blackduck portal for any vulnerability after my commit.

## Upload Screenshots/lists of the scenarios tested
Single tenant : 
<img width="421" height="58" alt="image" src="https://github.com/user-attachments/assets/2af5a63e-6840-4374-9653-5486f37c3c44" />
Multi tenant (Tenant 1) : 
<img width="351" height="64" alt="image" src="https://github.com/user-attachments/assets/942b8ea7-a1ff-48f9-8639-275ecd84bfdd" />
Multi tenant (Tenant 2) : 
<img width="351" height="64" alt="image" src="https://github.com/user-attachments/assets/942b8ea7-a1ff-48f9-8639-275ecd84bfdd" />
