### PR TITLE
fix for draft edit link

### DIFF
--- a/lib/sdm.js
+++ b/lib/sdm.js
@@ -1077,7 +1077,7 @@ let subdomain = cds.context?.user?.authInfo?.token?.payload?.ext_attr?.zdn;
         status: "Clean",
         type: "sap-icon://internet-browser",
         [upIdKey]: upId,
-        mimeType: response.data?.succinctProperties['cmis:contentStreamMimeType'],
+        mimeType: "application/internet-shortcut",
         filename: req.data?.name,
         HasDraftEntity: false,
         HasActiveEntity: false,
@@ -1148,27 +1148,30 @@ let subdomain = cds.context?.user?.authInfo?.token?.payload?.ext_attr?.zdn;
     }
   }
 
-  async handleDraftSaveForLinks() {
-    // Find all entities with attachment compositions
-    const allEntities = Object.keys(cds.model.definitions);
-    const entityPatterns = [];
+  async handleDraftSaveForLinks(data, req) {
+    const baseEntityName = req.target.name;
+    const attachmentCompositions = this.getAttachmentCompositions({ name: baseEntityName });
+    const parentId = req.data?.ID;
 
-    for (const entityName of allEntities) {
-      const entity = cds.model.definitions[entityName];
-      if (entity && entity.elements) {
-        const attachmentCompositions = this.getAttachmentCompositions({ name: entityName });
-        for (const composition of attachmentCompositions) {
-          entityPatterns.push(`${entityName}.${composition}`);
-          entityPatterns.push(`${entityName}.${composition}.drafts`);
-        }
-      }
-    }
+    for (const compositionName of attachmentCompositions) {
+      const attachmentsEntityName = `${baseEntityName}.${compositionName}`;
+      const attachmentsEntity = cds.model.definitions[attachmentsEntityName];
+      if (!attachmentsEntity) continue;
 
-    for (const entityName of entityPatterns) {
-      const attachmentsEntity = cds.model.definitions[entityName];
-      if (attachmentsEntity) {
-        await this.updateBaselinesForEntity(entityName);
+      const upKey = attachmentsEntity.keys?.up_?.keys?.[0]?.$generatedFieldName || 'up__ID';
+
+      // Fix mimeType for link attachments of this specific entity
+      if (parentId) {
+        await global.UPDATE(attachmentsEntityName)
+          .set({ mimeType: 'application/internet-shortcut' })
+          .where({
+            [upKey]: parentId,
+            linkUrl: { '!=': null },
+            mimeType: { '!=': 'application/internet-shortcut' }
+          });
       }
+
+      await this.updateBaselinesForEntity(attachmentsEntityName);
     }
   }
 

--- a/test/lib/sdm.test.js
+++ b/test/lib/sdm.test.js
@@ -3898,6 +3898,12 @@ describe("SDMAttachmentsService", () => {
       // FIX: Spy on the actual method to assert calls
       service.updateBaselinesForEntity = jest.fn();
       
+      // Mock global.UPDATE for mimeType fix using mockImplementation to avoid breaking other tests
+      global.UPDATE.mockClear().mockImplementation(() => ({
+        set: jest.fn().mockReturnThis(),
+        where: jest.fn().mockResolvedValue()
+      }));
+      
       req = {
         target: {
           name: 'Test.Entity.drafts'
@@ -3905,8 +3911,10 @@ describe("SDMAttachmentsService", () => {
       };
     });
     
-    it('should handle entity patterns when no target name', async () => {
-      req.target = {}; // Simulate no target name
+    it('should call updateBaselinesForEntity for attachment compositions', async () => {
+      // Set up proper target name
+      req.target = { name: 'ProcessorService.Incidents' };
+      req.data = { ID: 'test-id' };
       
       // Mock the parent entity with references composition
       cds.model.definitions['ProcessorService.Incidents'] = {
@@ -3921,31 +3929,30 @@ describe("SDMAttachmentsService", () => {
       // Mock the entity definitions that the method looks for
       cds.model.definitions['ProcessorService.Incidents.references'] = { 
         entity: 'TestAttachments',
-        includes: ['sap.attachments.Attachments']
-      };
-      cds.model.definitions['ProcessorService.Incidents.references.drafts'] = { 
-        entity: 'TestAttachmentsDrafts'
+        includes: ['sap.attachments.Attachments'],
+        keys: { up_: { keys: [{ $generatedFieldName: 'up__ID' }] } }
       };
       
-      await service.handleDraftSaveForLinks(req);
+      await service.handleDraftSaveForLinks({}, req);
       
-      // FIX: Assert calls to the spied function
+      // Assert updateBaselinesForEntity is called for the attachments entity
       expect(service.updateBaselinesForEntity).toHaveBeenCalledWith('ProcessorService.Incidents.references');
-      expect(service.updateBaselinesForEntity).toHaveBeenCalledWith('ProcessorService.Incidents.references.drafts');
-      expect(service.updateBaselinesForEntity).toHaveBeenCalledTimes(2);
+      expect(service.updateBaselinesForEntity).toHaveBeenCalledTimes(1);
     });
     
-    it('should not call updateBaselinesForEntity when target name is available', async () => {
-      // Target name is available: 'Test.Entity.drafts'
+    it('should not call updateBaselinesForEntity when no composition entities exist', async () => {
+      // Target name exists but no matching composition entities are defined
+      req.target = { name: 'Test.Entity.drafts' };
+      req.data = {};
       
       // Clean up entity definitions from previous test
       delete cds.model.definitions['ProcessorService.Incidents'];
       delete cds.model.definitions['ProcessorService.Incidents.references'];
       delete cds.model.definitions['ProcessorService.Incidents.references.drafts'];
       
-      await service.handleDraftSaveForLinks(req);
+      await service.handleDraftSaveForLinks({}, req);
       
-      // FIX: Assert NOT called when target name is present (as per sdm.js logic)
+      // updateBaselinesForEntity should not be called when composition entities don't exist
       expect(service.updateBaselinesForEntity).not.toHaveBeenCalled();
     });
   });


### PR DESCRIPTION
## Describe your changes

**Problem:** After saving an entity with a link attachment, the "Edit Link" button didn't appear when editing the entity again.

**Fix:** Restore correct [mimeType](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) for link attachments after save by checking if [linkUrl](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) exists and correcting the mimeType.


## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist before requesting a review

- [x] I have tested the functionality on my cloud environment.
- [x] I have  provided sufficient automated/ unit tests for the code.
- [x] I have increased or maintained the test coverage.
- [x] I have ran integration tests on my cloud environment.
- [x] I have validated blackduck portal for any vulnerability after my commit.

## Upload Screenshots/lists of the scenarios tested
- [x] I have Uploaded Screenshots or added lists of the scenarios tested in description

Single tenant Integration test
https://github.com/cap-js/sdm/actions/runs/22898011199

TENANCY_MODEL=multi TENANT=SDM-DEV-CONSUMER-EU12 npm run integration-test

<img width="821" height="458" alt="Screenshot 2026-03-10 at 4 26 23 PM" src="https://github.com/user-attachments/assets/c0ffd506-8ca8-4259-9c64-3ae45b337f8c" />

TENANCY_MODEL=multi TENANT=SDMGoogleWorkspaceConsumer npm run integration-test

<img width="796" height="531" alt="Screenshot 2026-03-10 at 4 31 28 PM" src="https://github.com/user-attachments/assets/b410083d-0679-43f4-b643-1b57a2cc3373" />




