### PR TITLE
DINC0866724:MTX-Service crash due to @cap-js/attachments dependency

### DIFF
--- a/lib/sdm.js
+++ b/lib/sdm.js
@@ -77,7 +77,7 @@ const {
 const { getDestinationFromServiceBinding,retrieveJwt} = require('@sap-cloud-sdk/connectivity');
 
 module.exports = class SDMAttachmentsService extends (
-  require("@cap-js/attachments/srv/basic")
+  require("@cap-js/attachments/srv/attachments/basic")
 ) {
   async init() {
     this.creds = this.options.credentials;

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "plugin"
   ],
   "dependencies": {
-    "@cap-js/attachments": "3.12.0",
+    "@cap-js/attachments": "3.12.1",
     "@sap-cloud-sdk/connectivity": "^4.3.1",
     "@sap-cloud-sdk/http-client": "^4.3.1",
     "@sap/xssec": "^4",
@@ -61,19 +61,22 @@
       "[development]": {
         "attachments": {
           "kind": "sdm",
-          "scan": false
+          "scan": false,
+          "deduplicateFileNames": false
         }
       },
       "[production]": {
         "attachments": {
           "kind": "sdm",
-          "scan": false
+          "scan": false,
+          "deduplicateFileNames": false
         }
       },
       "[hybrid]": {
         "attachments": {
           "kind": "sdm",
-          "scan": false
+          "scan": false,
+          "deduplicateFileNames": false
         }
       }
     }

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "plugin"
   ],
   "dependencies": {
-    "@cap-js/attachments": "3.8.0",
+    "@cap-js/attachments": "3.12.0",
     "@sap-cloud-sdk/connectivity": "^4.3.1",
     "@sap-cloud-sdk/http-client": "^4.3.1",
     "@sap/xssec": "^4",

--- a/test/lib/sdm.test.js
+++ b/test/lib/sdm.test.js
@@ -67,7 +67,7 @@ let {
   mimeTypeInvalidError
 } = require("../../lib/util/messageConsts");
 
-jest.mock("@cap-js/attachments/srv/basic", () => class {
+jest.mock("@cap-js/attachments/srv/attachments/basic", () => class {
   async init() {
     return Promise.resolve();
   }


### PR DESCRIPTION
MTX-Service crash due to @cap-js/attachments dependency

## Describe your changes
Updated package.json with cap-js/attachments 3.12.1
changed the failing code and unit tests accordingly.

#### Any documentation

-

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist before requesting a review

- [x] I have tested the functionality on my cloud environment.
- [x] I have  provided sufficient automated/ unit tests for the code.
- [x] I have increased or maintained the test coverage.
- [x] I have ran integration tests on my cloud environment.
- [ ] I have validated blackduck portal for any vulnerability after my commit.

## Upload Screenshots/lists of the scenarios tested
- [x] I have Uploaded Screenshots or added lists of the scenarios tested in description

<img width="1704" height="744" alt="Screenshot 2026-04-29 at 4 37 10 PM" src="https://github.com/user-attachments/assets/3577d453-fe63-41bb-af32-b47770d8f487" />
<img width="1721" height="948" alt="Screenshot 2026-05-06 at 3 00 04 PM" src="https://github.com/user-attachments/assets/a4081721-cc8d-472f-8914-f79c97656bb7" />
