### PR TITLE
DELETE on entities with Attachments composition fails when no SDM service is bound

### DIFF
--- a/lib/sdm.js
+++ b/lib/sdm.js
@@ -503,7 +503,6 @@ let subdomain = cds.context?.user?.authInfo?.token?.payload?.ext_attr?.zdn;
    * @returns {Function} - The draft save handler function
    */
   draftSaveHandler(attachments) {
-    console.log("SDM Credentials "+JSON.stringify(this.getSDMCredentials()));
     // Call parent's draftSaveHandler to get the base handler
     const parentHandler = super.draftSaveHandler(attachments);
     
@@ -669,7 +668,7 @@ let subdomain = cds.context?.user?.authInfo?.token?.payload?.ext_attr?.zdn;
   }
 
   async attachDeletionData(req) {
-    console.log("Credentials "+JSON.stringify(this.getSDMCredentials()));
+    if(!this.getSDMCredentials()){
     const attachmentCompositions = this.getAttachmentCompositions(req.target);
 
     for (const compositionName of attachmentCompositions) {
@@ -678,6 +677,7 @@ let subdomain = cds.context?.user?.authInfo?.token?.payload?.ext_attr?.zdn;
         const diffData = await req.diff();
         await this.processAttachmentDeletion(req, diffData, compositionName, attachments);
       }
+    }
     }
   }
 

--- a/lib/sdm.js
+++ b/lib/sdm.js
@@ -668,7 +668,7 @@ let subdomain = cds.context?.user?.authInfo?.token?.payload?.ext_attr?.zdn;
   }
 
   async attachDeletionData(req) {
-    if(!this.getSDMCredentials()){
+    if (this.getSDMCredentials()) {
     const attachmentCompositions = this.getAttachmentCompositions(req.target);
 
     for (const compositionName of attachmentCompositions) {

--- a/lib/sdm.js
+++ b/lib/sdm.js
@@ -503,7 +503,7 @@ let subdomain = cds.context?.user?.authInfo?.token?.payload?.ext_attr?.zdn;
    * @returns {Function} - The draft save handler function
    */
   draftSaveHandler(attachments) {
-    console.log("SDM Credentials "+this.getSDMCredentials());
+    console.log("SDM Credentials "+JSON.stringify(this.getSDMCredentials()));
     // Call parent's draftSaveHandler to get the base handler
     const parentHandler = super.draftSaveHandler(attachments);
     
@@ -669,7 +669,7 @@ let subdomain = cds.context?.user?.authInfo?.token?.payload?.ext_attr?.zdn;
   }
 
   async attachDeletionData(req) {
-    console.log("Credentials "+this.getSDMCredentials());
+    console.log("Credentials "+JSON.stringify(this.getSDMCredentials()));
     const attachmentCompositions = this.getAttachmentCompositions(req.target);
 
     for (const compositionName of attachmentCompositions) {

--- a/lib/sdm.js
+++ b/lib/sdm.js
@@ -503,6 +503,7 @@ let subdomain = cds.context?.user?.authInfo?.token?.payload?.ext_attr?.zdn;
    * @returns {Function} - The draft save handler function
    */
   draftSaveHandler(attachments) {
+    console.log("SDM Credentials "+this.getSDMCredentials());
     // Call parent's draftSaveHandler to get the base handler
     const parentHandler = super.draftSaveHandler(attachments);
     
@@ -668,6 +669,7 @@ let subdomain = cds.context?.user?.authInfo?.token?.payload?.ext_attr?.zdn;
   }
 
   async attachDeletionData(req) {
+    console.log("Credentials "+this.getSDMCredentials());
     const attachmentCompositions = this.getAttachmentCompositions(req.target);
 
     for (const compositionName of attachmentCompositions) {

--- a/test/lib/sdm.test.js
+++ b/test/lib/sdm.test.js
@@ -3014,6 +3014,7 @@ describe("SDMAttachmentsService", () => {
         }
       }
       service = new SDMAttachmentsService();
+      service.creds = { uri: "https://example.local" };
       NodeCache.prototype.get.mockImplementation(() => undefined);
       getConfigurations.mockResolvedValueOnce({repositoryId: "123"});
       getRepositoryInfo.mockResolvedValueOnce(repoInfo);
@@ -3214,6 +3215,26 @@ describe("SDMAttachmentsService", () => {
       getURLsToDeleteFromAttachments.mockResolvedValueOnce([]); // returning empty array
       await service.attachDeletionData(mockReq);
       expect(mockReq.attachmentsToDelete).toBeUndefined();
+    });
+
+    it("should skip deletion data processing when SDM credentials are missing", async () => {
+      service.creds = undefined;
+
+      const mockReq = {
+        target: { name: "myName" },
+        diff: jest.fn().mockResolvedValue({
+          references: [{ _op: "delete", ID: "1" }],
+        }),
+        event: "DELETE",
+      };
+
+      await service.attachDeletionData(mockReq);
+
+      expect(mockReq.diff).not.toHaveBeenCalled();
+      expect(getURLsToDeleteFromAttachments).not.toHaveBeenCalled();
+      expect(getFolderIdByIDAsPath).not.toHaveBeenCalled();
+      expect(mockReq.attachmentsToDelete).toBeUndefined();
+      expect(mockReq.parentId).toBeUndefined();
     });
   });
 


### PR DESCRIPTION
## Describe your changes
In version 1.10.0, when deleting an entity that has a Composition of many Attachments (from @cap-js/sdm), the operation fails with a 500 error in environments where no SDM service instance is bound in our case.

#### Any documentation

-Added a check if sdm binding does not exist do not execute the code.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist before requesting a review

- [x] I have tested the functionality on my cloud environment.
- [x] I have  provided sufficient automated/ unit tests for the code.
- [x] I have increased or maintained the test coverage.
- [x] I have ran integration tests on my cloud environment.
- [x] I have validated blackduck portal for any vulnerability after my commit.

## Upload Screenshots/lists of the scenarios tested
- [x] I have Uploaded Screenshots or added lists of the scenarios tested in description

<img width="1702" height="518" alt="Screenshot 2026-06-02 at 2 08 25 PM" src="https://github.com/user-attachments/assets/d10ae795-745d-4f64-adac-f47f116f4100" />

<img width="1698" height="479" alt="Screenshot 2026-06-03 at 1 14 30 PM" src="https://github.com/user-attachments/assets/add6435b-2893-4ac1-aa03-818a7e70e378" />
