### PR TITLE
fix: upgrade @cap-js/attachments to 3.13.0 to resolve arrify operational risk

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "plugin"
   ],
   "dependencies": {
-    "@cap-js/attachments": "3.12.1",
+    "@cap-js/attachments": "3.13.0",
     "@sap-cloud-sdk/connectivity": "^4.3.1",
     "@sap-cloud-sdk/http-client": "^4.3.1",
     "@sap/xssec": "^4",


### PR DESCRIPTION
## Summary
- Upgraded @cap-js/attachments from 3.12.1 to 3.13.0
- Resolves arrify operational risk (High) flagged in BlackDuck

## Change
\`"@cap-js/attachments": "3.12.1"\` → \`"3.13.0"\` in dependencies

## Test Plan
- [ ] \`npm install\` passes locally
- [ ] BlackDuck re-scan confirms operational risk resolved for arrify