### PR TITLE
fix: add npm override for node-fetch 3.3.2 to resolve operational risk

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,6 +49,9 @@
     "integration-test-virus-scan": "jest --config jest-integration-virus-scan.config.js",
     "lint": "npx eslint --fix . --no-cache"
   },
+  "overrides": {
+    "node-fetch": "3.3.2"
+  },
   "cds": {
     "server": {
       "body_parser": {


### PR DESCRIPTION
## Summary
- Added npm overrides entry for node-fetch to pin version 3.3.2
- Resolves node-fetch 2.7.0 operational risk (High) flagged in BlackDuck

## Change
Added to package.json overrides:
\`"node-fetch": "3.3.2"\`

## Test Plan
- [ ] \`npm install\` passes locally
- [ ] BlackDuck re-scan confirms operational risk resolved for node-fetch