### PR TITLE
Integration tests for Map Note field to CMIS description

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,6 +52,11 @@
     "lint": "npx eslint --fix . --no-cache"
   },
   "cds": {
+    "server": {
+      "body_parser": {
+        "limit": "2gb"
+      }
+    },
     "requires": {
       "sdm": {
         "vcap": {

--- a/test/integration/attachments-sdm-multifacet.test.js
+++ b/test/integration/attachments-sdm-multifacet.test.js
@@ -1891,9 +1891,11 @@ const config = {
     }
     expect(response.data.createdBy).toBeTruthy();
     expect(response.data.modifiedBy).toBeTruthy();
-    // When using named user token, createdBy should match the authenticated username
-    if (credentials.username) {
+
+    if (tokenFlow === 'namedUser' && credentials.username) {
       expect(response.data.createdBy).toBe(credentials.username);
+    } else if (tokenFlow === 'technicalUser' && credentials.username) {
+      expect(response.data.createdBy).not.toBe(credentials.username);
     }
 
     // Cleanup
@@ -2101,13 +2103,232 @@ describe('Attachments Integration Tests --CMIS METADATA', () => {
     const { getCmisProperty } = require('./utills/cmis-document-helper');
     const createdBy = await getCmisProperty(metadataEntityID, "metadata-test.pdf", "cmis:createdBy");
     expect(createdBy).toBeTruthy();
-    expect(createdBy).toBe(credentials.username);
+
+    if (tokenFlow === 'namedUser') {
+      expect(createdBy).toBe(credentials.username);
+    } else if (tokenFlow === 'technicalUser') {
+      expect(createdBy).not.toBe(credentials.username);
+    }
     console.log(`SDM createdBy field verified: ${createdBy}`);
 
     // Cleanup
     response = await api.deleteEntity(appUrl, serviceName, entityName, metadataEntityID);
     if (response.status !== "OK") {
       console.warn("Cleanup failed:", response.message);
+    }
+  });
+
+  itForAllFacets('should map attachment note to cmis:description on create', async () => {
+    const noteText = `note-create-${Date.now()}`;
+    let response = await api.createEntityDraft(appUrl, serviceName, entityName);
+    if (response.status !== "OK") {
+      throw new Error("Error : " + response.message);
+    }
+    const noteCreateEntityID = response.incidentID;
+
+    const file = {
+      filename: "note-create-file.pdf",
+      filepath: "./test/integration/sample.pdf"
+    };
+
+    const postData = {
+      up__ID: noteCreateEntityID,
+      mimeType: "application/pdf",
+      createdAt: new Date().toISOString(),
+      createdBy: "test@test.com",
+      modifiedBy: "test@test.com",
+      note: noteText
+    };
+
+    response = await api.createAttachment(appUrl, serviceName, entityName, noteCreateEntityID, postData, file);
+    if (response.status !== "OK") {
+      throw new Error("Error : " + response.message);
+    }
+
+    response = await api.saveEntityDraft(appUrl, serviceName, entityName, srvpath, noteCreateEntityID);
+    if (response.status !== "OK") {
+      throw new Error("Error : " + response.message);
+    }
+
+    const { getCmisProperty } = require('./utills/cmis-document-helper');
+    const cmisDescription = await getCmisProperty(noteCreateEntityID, "note-create-file.pdf", "cmis:description");
+    expect(cmisDescription).toBe(noteText);
+
+    response = await api.deleteEntity(appUrl, serviceName, entityName, noteCreateEntityID);
+    if (response.status !== "OK") {
+      console.warn("Cleanup failed for noteCreateEntityID:", response.message);
+    }
+  });
+
+  itForAllFacets('should map updated attachment note to cmis:description on update', async () => {
+    const initialNote = `note-initial-${Date.now()}`;
+    const updatedNote = `note-updated-${Date.now()}`;
+
+    let response = await api.createEntityDraft(appUrl, serviceName, entityName);
+    if (response.status !== "OK") {
+      throw new Error("Error : " + response.message);
+    }
+    const noteUpdateEntityID = response.incidentID;
+
+    const file = {
+      filename: "note-update-file.pdf",
+      filepath: "./test/integration/sample.pdf"
+    };
+
+    const postData = {
+      up__ID: noteUpdateEntityID,
+      mimeType: "application/pdf",
+      createdAt: new Date().toISOString(),
+      createdBy: "test@test.com",
+      modifiedBy: "test@test.com",
+      note: initialNote
+    };
+
+    response = await api.createAttachment(appUrl, serviceName, entityName, noteUpdateEntityID, postData, file);
+    if (response.status !== "OK") {
+      throw new Error("Error : " + response.message);
+    }
+    const noteUpdateAttachmentID = response.ID;
+
+    response = await api.saveEntityDraft(appUrl, serviceName, entityName, srvpath, noteUpdateEntityID);
+    if (response.status !== "OK") {
+      throw new Error("Error : " + response.message);
+    }
+
+    response = await api.editEntity(appUrl, serviceName, entityName, noteUpdateEntityID, srvpath);
+    if (response.status !== "OK") {
+      throw new Error("Error : " + response.message);
+    }
+
+    response = await api.updateAttachment(appUrl, serviceName, entityName, noteUpdateEntityID, { note: updatedNote }, noteUpdateAttachmentID);
+    if (response.status !== "OK") {
+      throw new Error("Error : " + response.message);
+    }
+
+    response = await api.saveEntityDraft(appUrl, serviceName, entityName, srvpath, noteUpdateEntityID);
+    if (response.status !== "OK") {
+      throw new Error("Error : " + response.message);
+    }
+
+    const { getCmisProperty } = require('./utills/cmis-document-helper');
+    const cmisDescription = await getCmisProperty(noteUpdateEntityID, "note-update-file.pdf", "cmis:description");
+    expect(cmisDescription).toBe(updatedNote);
+
+    response = await api.deleteEntity(appUrl, serviceName, entityName, noteUpdateEntityID);
+    if (response.status !== "OK") {
+      console.warn("Cleanup failed for noteUpdateEntityID:", response.message);
+    }
+  });
+
+  itForAllFacets('should map link note to cmis:description on create', async () => {
+    const noteText = `link-note-create-${Date.now()}`;
+    const linkName = `note-link-create-${Date.now()}`;
+    const linkUrl = 'https://example.com/create-note-link';
+
+    let response = await api.createEntityDraft(appUrl, serviceName, entityName);
+    if (response.status !== "OK") {
+      throw new Error("Error : " + response.message);
+    }
+    const linkNoteCreateEntityID = response.incidentID;
+
+    response = await api.createLink(appUrl, serviceName, entityName, linkNoteCreateEntityID, srvpath, linkName, linkUrl);
+    if (response.status !== "OK") {
+      throw new Error("Error : " + response.message);
+    }
+
+    response = await api.getAttachmentsList(appUrl, serviceName, entityName, linkNoteCreateEntityID);
+    if (response.status !== "OK") {
+      throw new Error("Error : " + response.message);
+    }
+
+    const linkAttachment = response.attachments.find(att =>
+      att.filename === linkName && att.linkUrl === linkUrl
+    );
+    if (!linkAttachment) {
+      throw new Error("Error : Created link not found in attachments list");
+    }
+
+    response = await api.updateAttachment(appUrl, serviceName, entityName, linkNoteCreateEntityID, { note: noteText }, linkAttachment.ID);
+    if (response.status !== "OK") {
+      throw new Error("Error : " + response.message);
+    }
+
+    response = await api.saveEntityDraft(appUrl, serviceName, entityName, srvpath, linkNoteCreateEntityID);
+    if (response.status !== "OK") {
+      throw new Error("Error : " + response.message);
+    }
+
+    const { getCmisProperty } = require('./utills/cmis-document-helper');
+    const cmisDescription = await getCmisProperty(linkNoteCreateEntityID, linkName, "cmis:description");
+    expect(cmisDescription).toBe(noteText);
+
+    response = await api.deleteEntity(appUrl, serviceName, entityName, linkNoteCreateEntityID);
+    if (response.status !== "OK") {
+      console.warn("Cleanup failed for linkNoteCreateEntityID:", response.message);
+    }
+  });
+
+  itForAllFacets('should map updated link note to cmis:description on update', async () => {
+    const initialNote = `link-note-initial-${Date.now()}`;
+    const updatedNote = `link-note-updated-${Date.now()}`;
+    const linkName = `note-link-update-${Date.now()}`;
+    const linkUrl = 'https://example.com/update-note-link';
+
+    let response = await api.createEntityDraft(appUrl, serviceName, entityName);
+    if (response.status !== "OK") {
+      throw new Error("Error : " + response.message);
+    }
+    const linkNoteUpdateEntityID = response.incidentID;
+
+    response = await api.createLink(appUrl, serviceName, entityName, linkNoteUpdateEntityID, srvpath, linkName, linkUrl);
+    if (response.status !== "OK") {
+      throw new Error("Error : " + response.message);
+    }
+
+    response = await api.getAttachmentsList(appUrl, serviceName, entityName, linkNoteUpdateEntityID);
+    if (response.status !== "OK") {
+      throw new Error("Error : " + response.message);
+    }
+
+    const linkAttachment = response.attachments.find(att =>
+      att.filename === linkName && att.linkUrl === linkUrl
+    );
+    if (!linkAttachment) {
+      throw new Error("Error : Created link not found in attachments list");
+    }
+
+    response = await api.updateAttachment(appUrl, serviceName, entityName, linkNoteUpdateEntityID, { note: initialNote }, linkAttachment.ID);
+    if (response.status !== "OK") {
+      throw new Error("Error : " + response.message);
+    }
+
+    response = await api.saveEntityDraft(appUrl, serviceName, entityName, srvpath, linkNoteUpdateEntityID);
+    if (response.status !== "OK") {
+      throw new Error("Error : " + response.message);
+    }
+
+    response = await api.editEntity(appUrl, serviceName, entityName, linkNoteUpdateEntityID, srvpath);
+    if (response.status !== "OK") {
+      throw new Error("Error : " + response.message);
+    }
+
+    response = await api.updateAttachment(appUrl, serviceName, entityName, linkNoteUpdateEntityID, { note: updatedNote }, linkAttachment.ID);
+    if (response.status !== "OK") {
+      throw new Error("Error : " + response.message);
+    }
+
+    response = await api.saveEntityDraft(appUrl, serviceName, entityName, srvpath, linkNoteUpdateEntityID);
+    if (response.status !== "OK") {
+      throw new Error("Error : " + response.message);
+    }
+
+    const { getCmisProperty } = require('./utills/cmis-document-helper');
+    const cmisDescription = await getCmisProperty(linkNoteUpdateEntityID, linkName, "cmis:description");
+    expect(cmisDescription).toBe(updatedNote);
+
+    response = await api.deleteEntity(appUrl, serviceName, entityName, linkNoteUpdateEntityID);
+    if (response.status !== "OK") {
+      console.warn("Cleanup failed for linkNoteUpdateEntityID:", response.message);
     }
   });
 });

--- a/test/integration/attachments-sdm.test.js
+++ b/test/integration/attachments-sdm.test.js
@@ -2051,6 +2051,220 @@ describe.only('Attachments Integration Tests --CMIS METADATA', () => {
       console.warn("Cleanup failed:", response.message);
     }
   });
+
+  it('should map attachment note to cmis:description on create', async () => {
+    const noteText = `note-create-${Date.now()}`;
+    let response = await api.createEntityDraft(appUrl, serviceName, entityName);
+    if (response.status !== "OK") {
+      throw new Error("Error : " + response.message);
+    }
+    const noteCreateEntityID = response.incidentID;
+
+    const file = {
+      filename: "note-create-file.pdf",
+      filepath: "./test/integration/sample.pdf"
+    };
+
+    const postData = {
+      up__ID: noteCreateEntityID,
+      mimeType: "application/pdf",
+      createdAt: new Date().toISOString(),
+      createdBy: "test@test.com",
+      modifiedBy: "test@test.com",
+      note: noteText
+    };
+
+    response = await api.createAttachment(appUrl, serviceName, entityName, noteCreateEntityID, postData, file);
+    if (response.status !== "OK") {
+      throw new Error("Error : " + response.message);
+    }
+
+    response = await api.saveEntityDraft(appUrl, serviceName, entityName, srvpath, noteCreateEntityID);
+    if (response.status !== "OK") {
+      throw new Error("Error : " + response.message);
+    }
+
+    const { getCmisProperty } = require('./utills/cmis-document-helper');
+    const cmisDescription = await getCmisProperty(noteCreateEntityID, "note-create-file.pdf", "cmis:description");
+    expect(cmisDescription).toBe(noteText);
+
+    response = await api.deleteEntity(appUrl, serviceName, entityName, noteCreateEntityID);
+    if (response.status !== "OK") {
+      console.warn("Cleanup failed for noteCreateEntityID:", response.message);
+    }
+  });
+
+  it('should map updated attachment note to cmis:description on update', async () => {
+    const initialNote = `note-initial-${Date.now()}`;
+    const updatedNote = `note-updated-${Date.now()}`;
+
+    let response = await api.createEntityDraft(appUrl, serviceName, entityName);
+    if (response.status !== "OK") {
+      throw new Error("Error : " + response.message);
+    }
+    const noteUpdateEntityID = response.incidentID;
+
+    const file = {
+      filename: "note-update-file.pdf",
+      filepath: "./test/integration/sample.pdf"
+    };
+
+    const postData = {
+      up__ID: noteUpdateEntityID,
+      mimeType: "application/pdf",
+      createdAt: new Date().toISOString(),
+      createdBy: "test@test.com",
+      modifiedBy: "test@test.com",
+      note: initialNote
+    };
+
+    response = await api.createAttachment(appUrl, serviceName, entityName, noteUpdateEntityID, postData, file);
+    if (response.status !== "OK") {
+      throw new Error("Error : " + response.message);
+    }
+    const noteUpdateAttachmentID = response.ID;
+
+    response = await api.saveEntityDraft(appUrl, serviceName, entityName, srvpath, noteUpdateEntityID);
+    if (response.status !== "OK") {
+      throw new Error("Error : " + response.message);
+    }
+
+    response = await api.editEntity(appUrl, serviceName, entityName, noteUpdateEntityID, srvpath);
+    if (response.status !== "OK") {
+      throw new Error("Error : " + response.message);
+    }
+
+    response = await api.updateAttachment(appUrl, serviceName, entityName, noteUpdateEntityID, { note: updatedNote }, noteUpdateAttachmentID);
+    if (response.status !== "OK") {
+      throw new Error("Error : " + response.message);
+    }
+
+    response = await api.saveEntityDraft(appUrl, serviceName, entityName, srvpath, noteUpdateEntityID);
+    if (response.status !== "OK") {
+      throw new Error("Error : " + response.message);
+    }
+
+    const { getCmisProperty } = require('./utills/cmis-document-helper');
+    const cmisDescription = await getCmisProperty(noteUpdateEntityID, "note-update-file.pdf", "cmis:description");
+    expect(cmisDescription).toBe(updatedNote);
+
+    response = await api.deleteEntity(appUrl, serviceName, entityName, noteUpdateEntityID);
+    if (response.status !== "OK") {
+      console.warn("Cleanup failed for noteUpdateEntityID:", response.message);
+    }
+  });
+
+  it('should map link note to cmis:description on create', async () => {
+    const noteText = `link-note-create-${Date.now()}`;
+    const linkName = `note-link-create-${Date.now()}`;
+    const linkUrl = 'https://example.com/create-note-link';
+
+    let response = await api.createEntityDraft(appUrl, serviceName, entityName);
+    if (response.status !== "OK") {
+      throw new Error("Error : " + response.message);
+    }
+    const linkNoteCreateEntityID = response.incidentID;
+
+    response = await api.createLink(appUrl, serviceName, entityName, linkNoteCreateEntityID, srvpath, linkName, linkUrl);
+    if (response.status !== "OK") {
+      throw new Error("Error : " + response.message);
+    }
+
+    response = await api.getAttachmentsList(appUrl, serviceName, entityName, linkNoteCreateEntityID);
+    if (response.status !== "OK") {
+      throw new Error("Error : " + response.message);
+    }
+
+    const linkAttachment = response.attachments.find(att =>
+      att.filename === linkName && att.linkUrl === linkUrl
+    );
+    if (!linkAttachment) {
+      throw new Error("Error : Created link not found in attachments list");
+    }
+
+    response = await api.updateAttachment(appUrl, serviceName, entityName, linkNoteCreateEntityID, { note: noteText }, linkAttachment.ID);
+    if (response.status !== "OK") {
+      throw new Error("Error : " + response.message);
+    }
+
+    response = await api.saveEntityDraft(appUrl, serviceName, entityName, srvpath, linkNoteCreateEntityID);
+    if (response.status !== "OK") {
+      throw new Error("Error : " + response.message);
+    }
+
+    const { getCmisProperty } = require('./utills/cmis-document-helper');
+    const cmisDescription = await getCmisProperty(linkNoteCreateEntityID, linkName, "cmis:description");
+    expect(cmisDescription).toBe(noteText);
+
+    response = await api.deleteEntity(appUrl, serviceName, entityName, linkNoteCreateEntityID);
+    if (response.status !== "OK") {
+      console.warn("Cleanup failed for linkNoteCreateEntityID:", response.message);
+    }
+  });
+
+  it('should map updated link note to cmis:description on update', async () => {
+    const initialNote = `link-note-initial-${Date.now()}`;
+    const updatedNote = `link-note-updated-${Date.now()}`;
+    const linkName = `note-link-update-${Date.now()}`;
+    const linkUrl = 'https://example.com/update-note-link';
+
+    let response = await api.createEntityDraft(appUrl, serviceName, entityName);
+    if (response.status !== "OK") {
+      throw new Error("Error : " + response.message);
+    }
+    const linkNoteUpdateEntityID = response.incidentID;
+
+    response = await api.createLink(appUrl, serviceName, entityName, linkNoteUpdateEntityID, srvpath, linkName, linkUrl);
+    if (response.status !== "OK") {
+      throw new Error("Error : " + response.message);
+    }
+
+    response = await api.getAttachmentsList(appUrl, serviceName, entityName, linkNoteUpdateEntityID);
+    if (response.status !== "OK") {
+      throw new Error("Error : " + response.message);
+    }
+
+    const linkAttachment = response.attachments.find(att =>
+      att.filename === linkName && att.linkUrl === linkUrl
+    );
+    if (!linkAttachment) {
+      throw new Error("Error : Created link not found in attachments list");
+    }
+
+    response = await api.updateAttachment(appUrl, serviceName, entityName, linkNoteUpdateEntityID, { note: initialNote }, linkAttachment.ID);
+    if (response.status !== "OK") {
+      throw new Error("Error : " + response.message);
+    }
+
+    response = await api.saveEntityDraft(appUrl, serviceName, entityName, srvpath, linkNoteUpdateEntityID);
+    if (response.status !== "OK") {
+      throw new Error("Error : " + response.message);
+    }
+
+    response = await api.editEntity(appUrl, serviceName, entityName, linkNoteUpdateEntityID, srvpath);
+    if (response.status !== "OK") {
+      throw new Error("Error : " + response.message);
+    }
+
+    response = await api.updateAttachment(appUrl, serviceName, entityName, linkNoteUpdateEntityID, { note: updatedNote }, linkAttachment.ID);
+    if (response.status !== "OK") {
+      throw new Error("Error : " + response.message);
+    }
+
+    response = await api.saveEntityDraft(appUrl, serviceName, entityName, srvpath, linkNoteUpdateEntityID);
+    if (response.status !== "OK") {
+      throw new Error("Error : " + response.message);
+    }
+
+    const { getCmisProperty } = require('./utills/cmis-document-helper');
+    const cmisDescription = await getCmisProperty(linkNoteUpdateEntityID, linkName, "cmis:description");
+    expect(cmisDescription).toBe(updatedNote);
+
+    response = await api.deleteEntity(appUrl, serviceName, entityName, linkNoteUpdateEntityID);
+    if (response.status !== "OK") {
+      console.warn("Cleanup failed for linkNoteUpdateEntityID:", response.message);
+    }
+  });
 });
 
 describe.only('Attachments Integration Tests --DELETE', () => {


### PR DESCRIPTION
## Describe your changes

This PR adds Integration tests for Map Note field to CMIS description for single facet and multi facet

Tests covered

1. should map attachment note to cmis:description on create
2. should map updated attachment note to cmis:description on update
3. should map link note to cmis:description on create
4. should map updated link note to cmis:description on update

## Upload Screenshots/lists of the scenarios tested
- [x] I have Uploaded Screenshots or added lists of the scenarios tested in description

<img width="879" height="585" alt="Screenshot 2026-06-30 at 8 08 47 AM" src="https://github.com/user-attachments/assets/9dae6c85-0bc8-492e-b9cb-86e7a46ea49c" />

<img width="667" height="792" alt="Screenshot 2026-06-30 at 9 36 34 AM" src="https://github.com/user-attachments/assets/81750644-ae45-492c-980e-a85886ef30c3" />


