### PR TITLE
Check to allow  programmatic CDS query.

### DIFF
--- a/lib/sdm.js
+++ b/lib/sdm.js
@@ -1655,7 +1655,7 @@ let subdomain = cds.context?.user?.authInfo?.token?.payload?.ext_attr?.zdn;
     let metadata = null;
 
     if (req.event === 'UPDATE' || req.event === 'PUT') {
-      attachmentID = req.req.url.match(attachmentIDRegex)[1];
+      attachmentID = req.req?.url?.match(attachmentIDRegex)?.[1] ?? req.data.ID;
 
       metadata = await cds.ql.SELECT.one.from(req.target)
         .where({ ID: attachmentID });

--- a/test/lib/sdm.test.js
+++ b/test/lib/sdm.test.js
@@ -6502,6 +6502,54 @@ describe("SDMAttachmentsService", () => {
         expect(mockReq.data.up__ID).toBe('123e4567-e89b-12d3-a456-426614174000');
       });
 
+      it("should handle programmatic UPDATE query without HTTP request object (no req.req)", async () => {
+        //Test for fix provided for failure caused when a CAP query is issued programmatically (not via an HTTP REST call), req.req is undefined — there is no underlying HTTP request object, so there's no URL to match against.
+        const mockReq = {
+          data: {
+            ID: '223e4567-e89b-12d3-a456-426614174000',
+            content: Buffer.from('updated content'),
+          },
+          target: { name: 'Orders.references', isDraft: false },
+          event: 'UPDATE',
+          // req.req is intentionally absent — simulates a programmatic CDS query
+          req: undefined,
+          reject: jest.fn(),
+        };
+
+        const mockMetadata = {
+          ID: '223e4567-e89b-12d3-a456-426614174000',
+          filename: 'existing.pdf',
+          up__ID: '123e4567-e89b-12d3-a456-426614174000',
+        };
+
+        SELECT.one.from.mockReturnValue({
+          where: jest.fn()
+            .mockResolvedValueOnce(mockMetadata)
+            .mockResolvedValueOnce({
+              ID: '223e4567-e89b-12d3-a456-426614174000',
+              url: 'updated-object-id',
+              folderId: 'parent-folder-id',
+              repositoryId: 'test-repo-id',
+              status: 'Clean',
+              type: 'sap-icon://document',
+            }),
+        });
+
+        isRestrictedCharactersInName.mockReturnValue(false);
+
+        // Should not throw — should fall back to req.data.ID when req.req is absent
+        await expect(service.nonDraftAttachmentCreateHandler(mockReq)).resolves.not.toThrow();
+
+        expect(service.onCreate).toHaveBeenCalledWith(
+          expect.arrayContaining([
+            expect.objectContaining({ ID: '223e4567-e89b-12d3-a456-426614174000', filename: 'existing.pdf' }),
+          ]),
+          service.creds,
+          mockReq,
+          'parent-folder-id',
+        );
+      });
+
       it("should reject if attachment not found during PUT", async () => {
         const mockReq = {
           data: { content: Buffer.from('content') },


### PR DESCRIPTION
## Describe your changes

Currently when uploading attachment content via a programmatic CDS query the app crashed because nonDraftAttachmentCreateHandler unconditionally read req.req.url to extract the attachment ID. Programmatic CDS queries have no underlying HTTP request, so req.req is undefined.

With this PR we will be fixing this issue. 

Integration tests

1. Multi-tenant: https://github.com/cap-js/sdm/actions/runs/29719450266
2. Single-tenant: https://github.com/cap-js/sdm/actions/runs/29247182024
## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist before requesting a review

- [x] I have tested the functionality on my cloud environment.
- [x] I have  provided sufficient automated/ unit tests for the code.
- [x] I have increased or maintained the test coverage.
- [x] I have ran integration tests on my cloud environment.
- [x] I have validated blackduck portal for any vulnerability after my commit.

## Upload Screenshots/lists of the scenarios tested
- [x] I have Uploaded Screenshots or added lists of the scenarios tested in description


