### PR TITLE
Fix CAP-JS : warn and error log level show info logs 

### DIFF
--- a/lib/ReadAheadStream.js
+++ b/lib/ReadAheadStream.js
@@ -1,7 +1,6 @@
 const { EventEmitter } = require('events');
 const cds = require('@sap/cds/lib');
 
-
 const LOG = cds.log('sdm', cds.env);
 
 /**

--- a/lib/ReadAheadStream.js
+++ b/lib/ReadAheadStream.js
@@ -1,6 +1,7 @@
 const { EventEmitter } = require('events');
 const cds = require('@sap/cds/lib');
 
+void cds.env; // ensure env is loaded before logger is cached so configured log level is applied
 const LOG = cds.log('sdm');
 
 /**

--- a/lib/ReadAheadStream.js
+++ b/lib/ReadAheadStream.js
@@ -2,8 +2,8 @@ const { EventEmitter } = require('events');
 const cds = require('@sap/cds/lib');
 
 cds.env; // ensure env is loaded before logger is cached so configured log level is applied
-const _cdsEnv = cds.env; // ensure env is loaded before logger is cached so configured log level is applied
-const LOG = cds.log('sdm');
+
+const LOG = cds.log('sdm', cds.env);
 
 /**
  * ReadAheadStream wraps a source stream and reads chunks into a bounded queue

--- a/lib/ReadAheadStream.js
+++ b/lib/ReadAheadStream.js
@@ -1,7 +1,7 @@
 const { EventEmitter } = require('events');
 const cds = require('@sap/cds/lib');
 
-void cds.env; // ensure env is loaded before logger is cached so configured log level is applied
+cds.env; // ensure env is loaded before logger is cached so configured log level is applied
 const LOG = cds.log('sdm');
 
 /**

--- a/lib/ReadAheadStream.js
+++ b/lib/ReadAheadStream.js
@@ -1,7 +1,6 @@
 const { EventEmitter } = require('events');
 const cds = require('@sap/cds/lib');
 
-cds.env; // ensure env is loaded before logger is cached so configured log level is applied
 
 const LOG = cds.log('sdm', cds.env);
 

--- a/lib/ReadAheadStream.js
+++ b/lib/ReadAheadStream.js
@@ -2,6 +2,7 @@ const { EventEmitter } = require('events');
 const cds = require('@sap/cds/lib');
 
 cds.env; // ensure env is loaded before logger is cached so configured log level is applied
+const _cdsEnv = cds.env; // ensure env is loaded before logger is cached so configured log level is applied
 const LOG = cds.log('sdm');
 
 /**

--- a/lib/handler/index.js
+++ b/lib/handler/index.js
@@ -7,6 +7,7 @@ const cds = require('@sap/cds');
 const { executeHttpRequest } = require('@sap-cloud-sdk/http-client');
 const ReadAheadStream = require('../ReadAheadStream');
 
+void cds.env; // ensure env is loaded before logger is cached so configured log level is applied
 const LOG = cds.log('sdm');
 
 const CHUNK_SIZE = 20 * 1024 * 1024;          // 20 MB per chunk

--- a/lib/handler/index.js
+++ b/lib/handler/index.js
@@ -8,6 +8,7 @@ const { executeHttpRequest } = require('@sap-cloud-sdk/http-client');
 const ReadAheadStream = require('../ReadAheadStream');
 
 cds.env; // ensure env is loaded before logger is cached so configured log level is applied
+const _cdsEnv = cds.env; // ensure env is loaded before logger is cached so configured log level is applied
 const LOG = cds.log('sdm');
 
 const CHUNK_SIZE = 20 * 1024 * 1024;          // 20 MB per chunk

--- a/lib/handler/index.js
+++ b/lib/handler/index.js
@@ -7,7 +7,6 @@ const cds = require('@sap/cds');
 const { executeHttpRequest } = require('@sap-cloud-sdk/http-client');
 const ReadAheadStream = require('../ReadAheadStream');
 
-
 const LOG = cds.log('sdm', cds.env);
 
 const CHUNK_SIZE = 20 * 1024 * 1024;          // 20 MB per chunk

--- a/lib/handler/index.js
+++ b/lib/handler/index.js
@@ -7,7 +7,6 @@ const cds = require('@sap/cds');
 const { executeHttpRequest } = require('@sap-cloud-sdk/http-client');
 const ReadAheadStream = require('../ReadAheadStream');
 
-cds.env; // ensure env is loaded before logger is cached so configured log level is applied
 
 const LOG = cds.log('sdm', cds.env);
 

--- a/lib/handler/index.js
+++ b/lib/handler/index.js
@@ -7,7 +7,7 @@ const cds = require('@sap/cds');
 const { executeHttpRequest } = require('@sap-cloud-sdk/http-client');
 const ReadAheadStream = require('../ReadAheadStream');
 
-void cds.env; // ensure env is loaded before logger is cached so configured log level is applied
+cds.env; // ensure env is loaded before logger is cached so configured log level is applied
 const LOG = cds.log('sdm');
 
 const CHUNK_SIZE = 20 * 1024 * 1024;          // 20 MB per chunk

--- a/lib/handler/index.js
+++ b/lib/handler/index.js
@@ -8,8 +8,8 @@ const { executeHttpRequest } = require('@sap-cloud-sdk/http-client');
 const ReadAheadStream = require('../ReadAheadStream');
 
 cds.env; // ensure env is loaded before logger is cached so configured log level is applied
-const _cdsEnv = cds.env; // ensure env is loaded before logger is cached so configured log level is applied
-const LOG = cds.log('sdm');
+
+const LOG = cds.log('sdm', cds.env);
 
 const CHUNK_SIZE = 20 * 1024 * 1024;          // 20 MB per chunk
 const FILE_SIZE_THRESHOLD = 400 * 1024 * 1024; // switch to chunked above 400 MB

--- a/lib/mtx/server.js
+++ b/lib/mtx/server.js
@@ -5,6 +5,7 @@ const { skippingOnboarding } = require("../util/messageConsts");
 const { executeHttpRequest } = require('@sap-cloud-sdk/http-client');
 const { getDestinationFromServiceBinding } = require('@sap-cloud-sdk/connectivity');
 cds.env; // ensure env is loaded before logger is cached so configured log level is applied
+const _cdsEnv = cds.env; // ensure env is loaded before logger is cached so configured log level is applied
 const LOG = cds.log('sdm');
 const profile = cds.env.profile;
 let configPath;

--- a/lib/mtx/server.js
+++ b/lib/mtx/server.js
@@ -4,7 +4,6 @@ const { getConfigurations, transformSDMServiceBindingToClientCredentialsDestinat
 const { skippingOnboarding } = require("../util/messageConsts");
 const { executeHttpRequest } = require('@sap-cloud-sdk/http-client');
 const { getDestinationFromServiceBinding } = require('@sap-cloud-sdk/connectivity');
-cds.env; // ensure env is loaded before logger is cached so configured log level is applied
 
 const LOG = cds.log('sdm', cds.env);
 const profile = cds.env.profile;

--- a/lib/mtx/server.js
+++ b/lib/mtx/server.js
@@ -4,7 +4,7 @@ const { getConfigurations, transformSDMServiceBindingToClientCredentialsDestinat
 const { skippingOnboarding } = require("../util/messageConsts");
 const { executeHttpRequest } = require('@sap-cloud-sdk/http-client');
 const { getDestinationFromServiceBinding } = require('@sap-cloud-sdk/connectivity');
-void cds.env; // ensure env is loaded before logger is cached so configured log level is applied
+cds.env; // ensure env is loaded before logger is cached so configured log level is applied
 const LOG = cds.log('sdm');
 const profile = cds.env.profile;
 let configPath;

--- a/lib/mtx/server.js
+++ b/lib/mtx/server.js
@@ -4,7 +4,6 @@ const { getConfigurations, transformSDMServiceBindingToClientCredentialsDestinat
 const { skippingOnboarding } = require("../util/messageConsts");
 const { executeHttpRequest } = require('@sap-cloud-sdk/http-client');
 const { getDestinationFromServiceBinding } = require('@sap-cloud-sdk/connectivity');
-
 const LOG = cds.log('sdm', cds.env);
 const profile = cds.env.profile;
 let configPath;

--- a/lib/mtx/server.js
+++ b/lib/mtx/server.js
@@ -4,6 +4,7 @@ const { getConfigurations, transformSDMServiceBindingToClientCredentialsDestinat
 const { skippingOnboarding } = require("../util/messageConsts");
 const { executeHttpRequest } = require('@sap-cloud-sdk/http-client');
 const { getDestinationFromServiceBinding } = require('@sap-cloud-sdk/connectivity');
+void cds.env; // ensure env is loaded before logger is cached so configured log level is applied
 const LOG = cds.log('sdm');
 const profile = cds.env.profile;
 let configPath;

--- a/lib/mtx/server.js
+++ b/lib/mtx/server.js
@@ -5,8 +5,8 @@ const { skippingOnboarding } = require("../util/messageConsts");
 const { executeHttpRequest } = require('@sap-cloud-sdk/http-client');
 const { getDestinationFromServiceBinding } = require('@sap-cloud-sdk/connectivity');
 cds.env; // ensure env is loaded before logger is cached so configured log level is applied
-const _cdsEnv = cds.env; // ensure env is loaded before logger is cached so configured log level is applied
-const LOG = cds.log('sdm');
+
+const LOG = cds.log('sdm', cds.env);
 const profile = cds.env.profile;
 let configPath;
 

--- a/lib/persistence/index.js
+++ b/lib/persistence/index.js
@@ -3,7 +3,6 @@ const {
   attachmentIDRegex
 } = require("../util/messageConsts");
 const { SELECT, UPDATE, INSERT } = cds.ql;
-
 const LOG = cds.log('sdm', cds.env);
 
 async function getURLFromAttachments(keys, attachments) {

--- a/lib/persistence/index.js
+++ b/lib/persistence/index.js
@@ -3,6 +3,7 @@ const {
   attachmentIDRegex
 } = require("../util/messageConsts");
 const { SELECT, UPDATE, INSERT } = cds.ql;
+void cds.env; // ensure env is loaded before logger is cached so configured log level is applied
 const LOG = cds.log('sdm');
 
 async function getURLFromAttachments(keys, attachments) {

--- a/lib/persistence/index.js
+++ b/lib/persistence/index.js
@@ -3,7 +3,7 @@ const {
   attachmentIDRegex
 } = require("../util/messageConsts");
 const { SELECT, UPDATE, INSERT } = cds.ql;
-void cds.env; // ensure env is loaded before logger is cached so configured log level is applied
+cds.env; // ensure env is loaded before logger is cached so configured log level is applied
 const LOG = cds.log('sdm');
 
 async function getURLFromAttachments(keys, attachments) {

--- a/lib/persistence/index.js
+++ b/lib/persistence/index.js
@@ -4,8 +4,8 @@ const {
 } = require("../util/messageConsts");
 const { SELECT, UPDATE, INSERT } = cds.ql;
 cds.env; // ensure env is loaded before logger is cached so configured log level is applied
-const _cdsEnv = cds.env; // ensure env is loaded before logger is cached so configured log level is applied
-const LOG = cds.log('sdm');
+
+const LOG = cds.log('sdm', cds.env);
 
 async function getURLFromAttachments(keys, attachments) {
   LOG.debug(`[DEBUG] [persistence] getURLFromAttachments keys=${JSON.stringify(keys)}`);

--- a/lib/persistence/index.js
+++ b/lib/persistence/index.js
@@ -4,6 +4,7 @@ const {
 } = require("../util/messageConsts");
 const { SELECT, UPDATE, INSERT } = cds.ql;
 cds.env; // ensure env is loaded before logger is cached so configured log level is applied
+const _cdsEnv = cds.env; // ensure env is loaded before logger is cached so configured log level is applied
 const LOG = cds.log('sdm');
 
 async function getURLFromAttachments(keys, attachments) {

--- a/lib/persistence/index.js
+++ b/lib/persistence/index.js
@@ -3,7 +3,6 @@ const {
   attachmentIDRegex
 } = require("../util/messageConsts");
 const { SELECT, UPDATE, INSERT } = cds.ql;
-cds.env; // ensure env is loaded before logger is cached so configured log level is applied
 
 const LOG = cds.log('sdm', cds.env);
 

--- a/lib/sdm.js
+++ b/lib/sdm.js
@@ -79,7 +79,7 @@ const {
 } = require("./util/messageConsts");
 const { getDestinationFromServiceBinding,retrieveJwt} = require('@sap-cloud-sdk/connectivity');
 const { executeHttpRequest } = require('@sap-cloud-sdk/http-client');
-cds.env; // ensure env is loaded before logger is cached so configured log level is applied
+const _cdsEnv = cds.env; // ensure env is loaded before logger is cached so configured log level is applied
 const LOG = cds.log('sdm');
 
 // Resolve the base class across @cap-js/attachments layouts: 3.8 ships it at

--- a/lib/sdm.js
+++ b/lib/sdm.js
@@ -79,7 +79,7 @@ const {
 } = require("./util/messageConsts");
 const { getDestinationFromServiceBinding,retrieveJwt} = require('@sap-cloud-sdk/connectivity');
 const { executeHttpRequest } = require('@sap-cloud-sdk/http-client');
-void cds.env; // ensure env is loaded before logger is cached so configured log level is applied
+cds.env; // ensure env is loaded before logger is cached so configured log level is applied
 const LOG = cds.log('sdm');
 
 // Resolve the base class across @cap-js/attachments layouts: 3.8 ships it at

--- a/lib/sdm.js
+++ b/lib/sdm.js
@@ -584,12 +584,6 @@ let subdomain = cds.context?.user?.authInfo?.token?.payload?.ext_attr?.zdn;
       LOG.debug('[DEBUG] [draftAttachmentUploadHandler] Processing draft upload request');
       LOG.info(`[INFO] [draftAttachmentUploadHandler] Upload started - Content-Length: ${contentLengthNum} bytes`);
 
-      // TEMP: all log levels test — remove before release
-      LOG.error('[TEMP] [uploadHandler] log level test: ERROR visible');
-      LOG.warn('[TEMP] [uploadHandler] log level test: WARN visible');
-      LOG.info('[TEMP] [uploadHandler] log level test: INFO visible');
-      LOG.debug('[TEMP] [uploadHandler] log level test: DEBUG visible');
-
       // Check virus scan before any SDM call — reject large files early.
       this._rejectIfVirusScanLargeFile(req, contentLengthNum);
 

--- a/lib/sdm.js
+++ b/lib/sdm.js
@@ -79,6 +79,7 @@ const {
 } = require("./util/messageConsts");
 const { getDestinationFromServiceBinding,retrieveJwt} = require('@sap-cloud-sdk/connectivity');
 const { executeHttpRequest } = require('@sap-cloud-sdk/http-client');
+void cds.env; // ensure env is loaded before logger is cached so configured log level is applied
 const LOG = cds.log('sdm');
 
 // Resolve the base class across @cap-js/attachments layouts: 3.8 ships it at

--- a/lib/sdm.js
+++ b/lib/sdm.js
@@ -79,7 +79,6 @@ const {
 } = require("./util/messageConsts");
 const { getDestinationFromServiceBinding,retrieveJwt} = require('@sap-cloud-sdk/connectivity');
 const { executeHttpRequest } = require('@sap-cloud-sdk/http-client');
-
 const LOG = cds.log('sdm', cds.env);
 
 // Resolve the base class across @cap-js/attachments layouts: 3.8 ships it at

--- a/lib/sdm.js
+++ b/lib/sdm.js
@@ -79,8 +79,8 @@ const {
 } = require("./util/messageConsts");
 const { getDestinationFromServiceBinding,retrieveJwt} = require('@sap-cloud-sdk/connectivity');
 const { executeHttpRequest } = require('@sap-cloud-sdk/http-client');
-const _cdsEnv = cds.env; // ensure env is loaded before logger is cached so configured log level is applied
-const LOG = cds.log('sdm');
+
+const LOG = cds.log('sdm', cds.env);
 
 // Resolve the base class across @cap-js/attachments layouts: 3.8 ships it at
 // "srv/basic", 3.12+ ships it at "srv/attachments/basic". Try both so the

--- a/lib/sdm.js
+++ b/lib/sdm.js
@@ -584,6 +584,12 @@ let subdomain = cds.context?.user?.authInfo?.token?.payload?.ext_attr?.zdn;
       LOG.debug('[DEBUG] [draftAttachmentUploadHandler] Processing draft upload request');
       LOG.info(`[INFO] [draftAttachmentUploadHandler] Upload started - Content-Length: ${contentLengthNum} bytes`);
 
+      // TEMP: all log levels test — remove before release
+      LOG.error('[TEMP] [uploadHandler] log level test: ERROR visible');
+      LOG.warn('[TEMP] [uploadHandler] log level test: WARN visible');
+      LOG.info('[TEMP] [uploadHandler] log level test: INFO visible');
+      LOG.debug('[TEMP] [uploadHandler] log level test: DEBUG visible');
+
       // Check virus scan before any SDM call — reject large files early.
       this._rejectIfVirusScanLargeFile(req, contentLengthNum);
 

--- a/lib/sdm.js
+++ b/lib/sdm.js
@@ -80,6 +80,7 @@ const {
 const { getDestinationFromServiceBinding,retrieveJwt} = require('@sap-cloud-sdk/connectivity');
 const { executeHttpRequest } = require('@sap-cloud-sdk/http-client');
 cds.env; // ensure env is loaded before logger is cached so configured log level is applied
+const _cdsEnv = cds.env; // ensure env is loaded before logger is cached so configured log level is applied
 const LOG = cds.log('sdm');
 
 // Resolve the base class across @cap-js/attachments layouts: 3.8 ships it at

--- a/lib/util/index.js
+++ b/lib/util/index.js
@@ -3,6 +3,7 @@ const NodeCache = require("node-cache");
 const { sdmAnnotationAdditionalpropertyName, sdmAnnotationAdditionalproperty, sdmAnnotationUseClientCredential } = require("./messageConsts");
 const cache = new NodeCache();
 const { jwtBearerToken, serviceToken, decodeJwt } = require('@sap-cloud-sdk/connectivity');
+void cds.env; // ensure env is loaded before logger is cached so configured log level is applied
 const LOG = cds.log('sdm');
 
 function isRepositoryVersioned(repoInfo, repositoryId) {

--- a/lib/util/index.js
+++ b/lib/util/index.js
@@ -4,8 +4,8 @@ const { sdmAnnotationAdditionalpropertyName, sdmAnnotationAdditionalproperty, sd
 const cache = new NodeCache();
 const { jwtBearerToken, serviceToken, decodeJwt } = require('@sap-cloud-sdk/connectivity');
 cds.env; // ensure env is loaded before logger is cached so configured log level is applied
-const _cdsEnv = cds.env; // ensure env is loaded before logger is cached so configured log level is applied
-const LOG = cds.log('sdm');
+
+const LOG = cds.log('sdm', cds.env);
 
 function isRepositoryVersioned(repoInfo, repositoryId) {
   let repoType = repoInfo.data[repositoryId].capabilities["capabilityContentStreamUpdatability"]

--- a/lib/util/index.js
+++ b/lib/util/index.js
@@ -4,6 +4,7 @@ const { sdmAnnotationAdditionalpropertyName, sdmAnnotationAdditionalproperty, sd
 const cache = new NodeCache();
 const { jwtBearerToken, serviceToken, decodeJwt } = require('@sap-cloud-sdk/connectivity');
 cds.env; // ensure env is loaded before logger is cached so configured log level is applied
+const _cdsEnv = cds.env; // ensure env is loaded before logger is cached so configured log level is applied
 const LOG = cds.log('sdm');
 
 function isRepositoryVersioned(repoInfo, repositoryId) {

--- a/lib/util/index.js
+++ b/lib/util/index.js
@@ -3,7 +3,6 @@ const NodeCache = require("node-cache");
 const { sdmAnnotationAdditionalpropertyName, sdmAnnotationAdditionalproperty, sdmAnnotationUseClientCredential } = require("./messageConsts");
 const cache = new NodeCache();
 const { jwtBearerToken, serviceToken, decodeJwt } = require('@sap-cloud-sdk/connectivity');
-cds.env; // ensure env is loaded before logger is cached so configured log level is applied
 
 const LOG = cds.log('sdm', cds.env);
 

--- a/lib/util/index.js
+++ b/lib/util/index.js
@@ -3,7 +3,7 @@ const NodeCache = require("node-cache");
 const { sdmAnnotationAdditionalpropertyName, sdmAnnotationAdditionalproperty, sdmAnnotationUseClientCredential } = require("./messageConsts");
 const cache = new NodeCache();
 const { jwtBearerToken, serviceToken, decodeJwt } = require('@sap-cloud-sdk/connectivity');
-void cds.env; // ensure env is loaded before logger is cached so configured log level is applied
+cds.env; // ensure env is loaded before logger is cached so configured log level is applied
 const LOG = cds.log('sdm');
 
 function isRepositoryVersioned(repoInfo, repositoryId) {

--- a/lib/util/index.js
+++ b/lib/util/index.js
@@ -3,7 +3,6 @@ const NodeCache = require("node-cache");
 const { sdmAnnotationAdditionalpropertyName, sdmAnnotationAdditionalproperty, sdmAnnotationUseClientCredential } = require("./messageConsts");
 const cache = new NodeCache();
 const { jwtBearerToken, serviceToken, decodeJwt } = require('@sap-cloud-sdk/connectivity');
-
 const LOG = cds.log('sdm', cds.env);
 
 function isRepositoryVersioned(repoInfo, repositoryId) {


### PR DESCRIPTION
## Describe your changes
Problem
The cds.log('sdm') logger was being initialized before cds.env was fully loaded in several modules. This caused any log level configured via cds.env.log.levels.sdm (e.g. in package.json or .cdsrc.json) to be ignored — the logger always defaulted to its built-in level instead of the user-configured one.

Fix
Added void cds.env; before each cds.log('sdm') call across all affected modules. This ensures the CDS environment (and its log level config) is loaded before the logger instance is cached.

Files changed:

lib/sdm.js
lib/handler/index.js
lib/persistence/index.js
lib/util/index.js
lib/ReadAheadStream.js
lib/mtx/server.js

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist before requesting a review

- [x] I have tested the functionality on my cloud environment.
- [x] I have  provided sufficient automated/ unit tests for the code.
- [x] I have increased or maintained the test coverage.
- [x] I have ran integration tests on my cloud environment.
- [x] I have validated blackduck portal for any vulnerability after my commit.

## Upload Screenshots/lists of the scenarios tested
- [ ] I have Uploaded Screenshots or added lists of the scenarios tested in description

Single Tenant : https://github.com/cap-js/sdm/actions/runs/31780938349
Multi Tenant : https://github.com/cap-js/sdm/actions/runs/31780959483

